### PR TITLE
Template updates, mostly optimizing for smaller images

### DIFF
--- a/templates/01a_simple_plot_SAT.html
+++ b/templates/01a_simple_plot_SAT.html
@@ -1,0 +1,11 @@
+<script type="text/graphie" data-use-SAT="true" data-title="1a. Simple plot (SAT style)">
+style({
+    stroke: BLUE_D,
+    fill: "none",
+    strokeWidth: 3
+});
+plot(function(x) {
+    // Write down the function you want to plot here
+    return -0.5 * x * x + 2 * x + 3.0;
+}, X_RANGE);
+</script>

--- a/templates/02_piecewise_function.html
+++ b/templates/02_piecewise_function.html
@@ -13,6 +13,6 @@ plot(function(x) {
     return x - 7.0;
 }, [3, 10]);
 
-ellipse([3, 4.5], [4 / xScale, 4 / yScale], {fill: BLUE});
+ellipse([3, 4.5], [4 / xScale, 4 / yScale], {fill: BLUE_D});
 ellipse([3, -4], [4 / xScale, 4 / yScale], {fill: "white"});
 </script>

--- a/templates/03_parametric_plots.html
+++ b/templates/03_parametric_plots.html
@@ -11,7 +11,7 @@ plotParametric(function(t) {
 }, Y_RANGE);
 
 style({
-    stroke: GREEN,
+    stroke: GREEN_D,
     fill: "none"
 });
 

--- a/templates/05_tape_diagram.html
+++ b/templates/05_tape_diagram.html
@@ -1,7 +1,6 @@
 <script type="text/graphie" data-title="5. Tape diagram">
 // Top label for the entire tape
 var TOP_LABEL = "Original Price";
-
 // Labels for each division. Add as many divisions as you like
 var LABELS = [
         "20\\%",
@@ -10,41 +9,31 @@ var LABELS = [
         "20\\%",
         "20\\%",
     ];
-
 // Label for the left partition
 var BOT_LEFT_LABEL = "Sale Price";
-
 // Number of divisions in the left partition
 var BREAK = 4;
-
 // Label for the right partition
 var BOT_RIGHT_LABEL = "$5";
-
 ///////////////////////////////////////////////////////////
-
-var scale = 40;
+var scale = 32;
 init({
     range: [[-0.1, 10.1], [0, 4]],
     scale: scale
 });
-
 style({ stroke: BLUE_D, strokeWidth: 2 });
-
 var fullWidth = 10;
 var half = fullWidth / 2;
-
 var boxWidth = fullWidth / LABELS.length;
 _.each(LABELS, function(lbl, n) {
     path([[boxWidth * n, 1.5], [boxWidth * (n + 1), 1.5],
           [boxWidth * (n + 1), 2.5], [boxWidth * n, 2.5], true]);
     label([boxWidth * (n + 0.5), 2], lbl);
 });
-
 var br = BREAK / LABELS.length;
 var pad = 2 / scale;
 var topY = 2.8;
-var top = curlyBrace([pad, topY], [fullWidth - pad, topY]);
-
+var topCurly = curlyBrace([pad, topY], [fullWidth - pad, topY]);
 var bottomY = 0.9;
 var bottomLeft = curlyBrace([br * fullWidth - pad, bottomY], [pad, bottomY]);
 var bottomRightPts = [
@@ -52,14 +41,10 @@ var bottomRightPts = [
     [br * fullWidth + pad, bottomY]
 ];
 var bottomRight = curlyBrace(bottomRightPts[0], bottomRightPts[1]);
-
-
-_.each([top, bottomLeft, bottomRight], function (brace) {
+_.each([topCurly, bottomLeft, bottomRight], function (brace) {
     brace.attr({ stroke: GRAY, "stroke-width": 1.5 });
 });
-
 label([half, 3.1], TOP_LABEL, "above", false);
 label([half * br, 0.9], BOT_LEFT_LABEL, "below", false);
 label([half * br + half, 0.9], BOT_RIGHT_LABEL, "below");
-
 </script>

--- a/templates/06_area_model.html
+++ b/templates/06_area_model.html
@@ -10,7 +10,7 @@ var CHART = [
 
 init({
     range: [[0, 1], [0, CHART.length]],
-    scale: [400,30]
+    scale: [320,30]
 });
 
 _.each(CHART.reverse(), function(row, n) {

--- a/templates/07_number_line.html
+++ b/templates/07_number_line.html
@@ -1,7 +1,9 @@
 <script type="text/graphie" data-title="7. Number line">
 var RANGE = [-5, 10];
-var TICK_STEP = 1;
+var TICK_STEP = 1; //"auto" or a number
+var LABEL_STEP = "auto"; //"auto" or a multiple of TICK_STEP
 var LABEL_TICKS = true;
+var ARROW_DIRECTION = "<->"; // "-", "->" or "<->"
 
 var LABELS = [
     {
@@ -24,20 +26,29 @@ var HIGHLIGHTED_TICKS = [
 
 var POINTS = [
     [ 2, RED_D ],
-]
+];
 
 var CIRCLES = [
     [ -4, RED_D ],
-]
+];
 
 var ARROWS = [
     [ 2, 12, RED_D ],
     [ -4, -7, RED_D ],
-]
+];
 
 ///////////////////////////////////////////////////////////////
 
-var SCALE = 400 / (RANGE[1] - RANGE[0]);
+var SCALE = 320 / (RANGE[1] - RANGE[0]);
+
+if(LABEL_STEP ==="auto"){
+    LABEL_STEP=Perseus.Util.tickStepFromExtent(
+                    RANGE, 320);
+}
+if(TICK_STEP==="auto"){
+    TICK_STEP= Perseus.Util.gridStepFromTickStep(LABEL_STEP, SCALE);
+}
+LABEL_STEP=floor(LABEL_STEP/TICK_STEP)*TICK_STEP;
 
 init({
     range: [[RANGE[0] - (30 / SCALE), RANGE[1] + (30 / SCALE)],
@@ -49,23 +60,60 @@ var minusIgnorer = function(a) {
     return (a + "").replace(/-(\d)/g, "\\llap{-}$1");
 };
 
-line([RANGE[0] - (25 / SCALE), 0],
-     [RANGE[1] + (25 / SCALE), 0], {
-    arrows: "->"
-});
+switch(ARROW_DIRECTION){
+    case "-":
+        line([RANGE[0] - (25 / SCALE), 0],
+             [RANGE[1] + (25 / SCALE), 0]);        
+        break;
+    case "<->":
+        line([RANGE[0] - (25 / SCALE), 0],
+             [RANGE[1] + (25 / SCALE), 0], {
+            arrows: "->"
+        });
+        
+        line([RANGE[1] + (25 / SCALE), 0],
+             [RANGE[0] - (25 / SCALE), 0], {
+            arrows: "->"
+        });        
+        break;
+    case "<-": //Not sure why you'd want this, but here it is
+        line([RANGE[1] + (25 / SCALE), 0],
+             [RANGE[0] - (25 / SCALE), 0], {
+            arrows: "->"
+        });        
+        break;    
+    default:
+        line([RANGE[0] - (25 / SCALE), 0],
+             [RANGE[1] + (25 / SCALE), 0], {
+            arrows: "->"
+        });        
+        break;
+}
 
-line([RANGE[1] + (25 / SCALE), 0],
-     [RANGE[0] - (25 / SCALE), 0], {
-    arrows: "->"
-});
-
-for (var x = RANGE[0]; x <= RANGE[1];
+for (var x = parseInt(RANGE[0]/TICK_STEP,10)*TICK_STEP; x <= RANGE[1];
         x = roundTo(10, x + TICK_STEP)) {
     line([x, -0.2], [x, 0.2]);
-    if (LABEL_TICKS && !_.findWhere(LABELS,
+    if (LABEL_TICKS && (x%LABEL_STEP)===0 && !_.findWhere(LABELS,
             {value: x, position: "below"})) {
         label([x, -0.53],  minusIgnorer(x), "center");
     }
+}
+
+//Don't throw errors if user deleted an array they didn't need
+if(!LABELS){
+    var LABELS=[];
+}
+if(!HIGHLIGHTED_TICKS){
+    var HIGHLIGHTED_TICKS=[];
+}
+if(!POINTS){
+    var POINTS=[];
+}
+if(!CIRCLES){
+    var CIRCLES=[];
+}
+if(!ARROWS){
+    var ARROWS=[];
 }
 
 if (typeof(LABELS) !== "undefined") {
@@ -110,7 +158,7 @@ if (typeof(ARROWS) !== "undefined") {
 if (typeof(POINTS) !== "undefined") {
     _.each(POINTS, function(point) {
         ellipse([point[0], 0],
-                [5 / (400 / (RANGE[1] - RANGE[0])), 5 / 40], {
+                [5 / (320 / (RANGE[1] - RANGE[0])), 5 / 40], {
             fill: point[1],
             stroke: null
         });
@@ -120,7 +168,7 @@ if (typeof(POINTS) !== "undefined") {
 if (typeof(CIRCLES) !== "undefined") {
     _.each(CIRCLES, function(point) {
         ellipse([point[0], 0],
-                [5 / (400 / (RANGE[1] - RANGE[0])), 5 / 40], {
+                [5 / (320 / (RANGE[1] - RANGE[0])), 5 / 40], {
             fill: _BACKGROUND,
             stroke: point[1],
             strokeWidth: 3

--- a/templates/08_place_value_blocks.html
+++ b/templates/08_place_value_blocks.html
@@ -4,10 +4,10 @@ var SHOW_LABELS = true;
 
 //////////////////////////////////////////////////////////////
 
-var thousands = floor(NUMBER / 1000)
-var hundreds = floor(NUMBER % 1000 / 100)
-var tens = floor(NUMBER % 100 / 10)
-var ones = NUMBER % 10
+var thousands = floor(NUMBER / 1000);
+var hundreds = floor(NUMBER % 1000 / 100);
+var tens = floor(NUMBER % 100 / 10);
+var ones = NUMBER % 10;
 
 var yMax = max(ones + 1.5,
                tens > 0 ? 11.5 : 0,
@@ -18,14 +18,14 @@ init({
     range: [[0, 3 + (tens * 2) + (hundreds * 11) +
             (thousands * 16)],
             [SHOW_LABELS ? -1 : 0, yMax]],
-    scale: [20, 20]
+    scale: [15,15]
 });
 
 var drawCube = function(x, y) {
     path([[x, y + 1],  [x, y], [x + 1, y], [x + 1.5, y + 0.5],
         [x + 1.5, y + 1.5], [x + 0.5, y + 1.5], true]);
     path([[x, y + 1], [x + 1, y + 1], [x + 1, y]]);
-    path([[x + 1, y + 1], [x + 1.5, y + 1.5]])
+    path([[x + 1, y + 1], [x + 1.5, y + 1.5]]);
 };
 
 style({ fill: BLUE_A, stroke: BLUE_D });

--- a/templates/11_pie_chart.html
+++ b/templates/11_pie_chart.html
@@ -30,15 +30,17 @@ var maxX = _.max(_.pluck(boundingBoxes, 1)) + pad;
 var minY = _.min(_.pluck(boundingBoxes, 2)) - pad;
 var maxY = _.max(_.pluck(boundingBoxes, 3)) + pad;
 
+var scaleFactor=min(1,320/(maxX-minX));
+
 init({
     range: [[minX, maxX], [minY, maxY]],
-    scale: 1
+    scale: scaleFactor,
 });
 
 _.each(CHART, function(row, n) {
     var tr = row[3];
     var color = row[4];
-    piechart(row[0], row[1], row[2], color).translate(tr[0], tr[1]);
+    piechart(row[0], row[1], row[2]*scaleFactor, color).translate(tr[0]*scaleFactor, tr[1]*scaleFactor);
 });
 
 </script>

--- a/templates/12_area_model_2.html
+++ b/templates/12_area_model_2.html
@@ -1,10 +1,10 @@
 <script type="text/graphie" data-title="12. Area model 2">
 // The total width is the sum of these plus 70, so keep the sum of
-// these to no more than 410.
-var WIDTHS = [210, 130, 70];
+// these to no more than 250.
+var WIDTHS = [110, 80, 60];
 var HEIGHTS = [
-    130,
-    70
+    80,
+    60
 ];
 var PAD = 1;
 
@@ -40,7 +40,7 @@ init({
 style({
     fillOpacity: 0.5,
     strokeOpacity: 0
-})
+});
 
 _.each(COLORS, function(row, j) {
     _.each(row, function(color, i) {

--- a/templates/13_intro_to_the_drawing_api.html
+++ b/templates/13_intro_to_the_drawing_api.html
@@ -3,45 +3,45 @@
 var range = [[-10, 10], [-10, 10]];
 
 /* The output's largest side is limited to this many pixels */
-var size = 400;
+var size = 320;
 
 setup();
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 drawLine({
-    points: [[-5, 8.5], [5, 8.5]],
+    points: [[-5, 8], [5, 8]],
     showPoints: true, // whether to actually show points
     vertexLabels: ["A", "B"],
     color: BLUE_D // changes the color of both line and labels
 });
 
 drawSegment({
-    points: [[-5, 7], [5, 7]],
+    points: [[-5, 6], [5, 6]],
     dashed: true,
     sideLabel: "x",
     stroke: GREEN_D // only changes the color of the line
 });
 
 drawRay({
-    points: [[-5, 6], [5, 6]],
+    points: [[-5, 5], [5, 5]],
     dotted: true
 });
 
 drawRay({
-    point: [-5, 5], // you can also create a ray from one point
+    point: [-5, 4], // you can also create a ray from one point
     angle: 0,       // and an angle direction
     dashed: true,
     dotted: true
 });
 
 drawPoint({
-    point: [-7, 7],
+    point: [-7, 6],
     label: "Y",
     color: MAROON_D // changes the color of both point and labels
 });
 
 drawPoint({
-    point: [7, 7],
+    point: [7, 6],
     label: "Z",
     stroke: PURPLE_C, // only changes the color of the point
     fill: PURPLE_C    // only changes the color of the point
@@ -50,9 +50,9 @@ drawPoint({
 // For much more about polygons, see template #17 (Polygon)
 drawPolygon({
     points: [
-        [-7, 0],
-        [-7, 4],
-        [-4, 0]
+        [-7, -1],
+        [-7, 3],
+        [-4, -1]
     ],
     vertexLabels: ["A", "B", "C"],
     arcs: 1,
@@ -117,7 +117,7 @@ drawSegment({
 
 drawAngleLabel({
     points: [[6, 0], [3, 0], onCircle], // in clockwise order
-    label: "$deg2", // "$deg" is relaced by angle measure
+    label: "$deg1", // "$deg" is relaced by angle measure
     arcs: 2         // the 2 means 2 decimal places are shown
 });
 

--- a/templates/14_angle_between_lines.html
+++ b/templates/14_angle_between_lines.html
@@ -11,7 +11,8 @@ drawLine({
 
 drawLine({
     points: [c, d],
-    color: BLUE_D
+    color: BLUE_D,
+    strokeWidth: 3,
 });
 
 drawAngleLabel({

--- a/templates/16_complementary_angles_2.html
+++ b/templates/16_complementary_angles_2.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[-1, 4], [-4, 1]]" data-title="16. Complementary angles 2">
+<script type="text/graphie" data-use-simple="true" data-range="[[-1, 4], [-4, 1]]" data-title="16. Adjacent angles">
 var a = [0, 0],
     b = polar(1, -40),
     c = polar(1, -10),

--- a/templates/17_polygon.html
+++ b/templates/17_polygon.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[-2, 10], [-2, 6]]" data-title="17. Polygon">
+<script type="text/graphie" data-use-simple="true" data-range="[[-1, 9], [-1, 5]]" data-title="17. Polygon">
 drawPolygon({
     // This polygon has 4 points, but you can have much more!
     points: [

--- a/templates/18_regular_polygon.html
+++ b/templates/18_regular_polygon.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-title="18. Regular Polygon">
+<script type="text/graphie" data-use-simple="true" data-range="[[-9, 9], [-7, 9]]" data-title="18. Regular Polygon">
 var n = 5; // number of sides
 
 var angle = 2 * Math.PI / n;

--- a/templates/19_simple_figure.html
+++ b/templates/19_simple_figure.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[-1, 11], [-4, 7]]" data-title="19. Simple Figure">
+<script type="text/graphie" data-use-simple="true" data-range="[[-1, 11], [-3, 6]]" data-title="19. Simple Figure">
 drawPolygon({
     points: [[0, 0], [0, 3], [7, 3], [7, 0]],
     sideLabels: ["$len0"],

--- a/templates/20_complex_figure.html
+++ b/templates/20_complex_figure.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[-5, 5], [-5, 5]]" data-title="20. Complex Figure">
+<script type="text/graphie" data-use-simple="true" data-range="[[-4,4], [-4,4]]" data-title="20. Complex Figure">
 var inner = 1.5;
 inner /= 2;
 

--- a/templates/21_3d_example.html
+++ b/templates/21_3d_example.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[-2, 2], [-2, 2]]" data-title="21. 3D Example">
+<script type="text/graphie" data-use-simple="true" data-range="[[-1.4, 1.1], [-1.2, 0.8]]" data-title="21. 3D Example">
 var color1 = GREEN_B;
 var color2 = GOLD_B;
 var color3 = BLUE_B;

--- a/templates/22_rectangular_prism_net.html
+++ b/templates/22_rectangular_prism_net.html
@@ -1,45 +1,4 @@
 <script type="text/graphie" data-use-simple="true" data-range="[[0, 11.5], [0, 9.5]]" data-title="22. Rectangular Prism Net">
-/* Helper functions for drawing simple polygons            */
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-var rotatePoints = function(center, angle, points) {
-    return _.map(points, function(pt) {
-        return rotatePoint(pt, angle, center);
-    });
-};
-
-var drawSimpleRectangle = function(description) {
-    var x = description.x || 0;
-    var y = description.y || 0;
-    var rotate = description.rotate || 0;
-    var width  = description.width || 1;
-    var height = description.height || 1;
-    var showLabels = description.showLabels || false;
-
-    var points = rotatePoints([x, y], rotate, [
-            [x - width/2, y - height/2],
-            [x - width/2, y + height/2],
-            [x + width/2, y + height/2],
-            [x + width/2, y - height/2]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [
-            null,
-            null,
-            showLabels ? "$len0" : null,
-            showLabels ? "$len0" : null
-        ],
-        ticks: description.ticks,
-        fill: GREEN,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-};
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
-
 var showLabels = true;
 
 drawSimpleRectangle({
@@ -94,4 +53,45 @@ drawSimpleRectangle({
     showLabels: showLabels,
     ticks: [3, 2, 3, 2]
 });
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+/* Helper functions for drawing simple polygons            */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+function rotatePoints(center, angle, points) {
+    return _.map(points, function(pt) {
+        return rotatePoint(pt, angle, center);
+    });
+}
+
+function drawSimpleRectangle(description) {
+    var x = description.x || 0;
+    var y = description.y || 0;
+    var rotate = description.rotate || 0;
+    var width  = description.width || 1;
+    var height = description.height || 1;
+    var showLabels = description.showLabels || false;
+
+    var points = rotatePoints([x, y], rotate, [
+            [x - width/2, y - height/2],
+            [x - width/2, y + height/2],
+            [x + width/2, y + height/2],
+            [x + width/2, y - height/2]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [
+            null,
+            null,
+            showLabels ? "$len0" : null,
+            showLabels ? "$len0" : null
+        ],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+}
 </script>

--- a/templates/23_square_pyramid_net.html
+++ b/templates/23_square_pyramid_net.html
@@ -1,98 +1,5 @@
 <script type="text/graphie" data-use-simple="true" data-range="[[0, 11], [0, 11]]" data-title="23. Square Pyramid Net">
-/* The X and Y ranges of this canvas */
-var range = [[0, 11], [0, 11]];
-
-/* The output's largest side is limited to this many pixels */
-var size = 400;
-
-setup();
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
-/* Helper functions for drawing simple polygons            */
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-var triangleHeight = sqrt(3)/2;
-var triangleOffset = triangleHeight/3;
-var triangleBuffer = 1/2 - triangleOffset;
-
-var rotatePoints = function(center, angle, points) {
-    return _.map(points, function(pt) {
-        return rotatePoint(pt, angle, center);
-    });
-};
-
-var drawSimpleTriangle = function(description) {
-    var x      = description.x || 0;
-    var y      = description.y || 0;
-    var rotate = description.rotate || 0;
-    var base   = description.base || 1;
-    var height = description.height || triangleHeight * base;
-    var showLabels = description.showLabels || false;
-    var centerOffset = description.centerOffset === undefined ?
-            height/3 :
-            description.centerOffset;
-
-    var points = rotatePoints([x, y], rotate, [
-        [x - base/2, y - centerOffset],
-        [x, y + height - centerOffset],
-        [x + base/2, y - centerOffset]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [null, null, showLabels ? "$len0" : null],
-        ticks: description.ticks,
-        fill: GREEN_D,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-    if (showLabels) {
-        baseMidpoint = lineMidpoint([points[0], points[2]]);
-        drawSegment({
-            points: [points[1], baseMidpoint],
-            dashed: true,
-            sideLabel: "$len0",
-            stroke: GREEN_E
-        });
-        drawAngleLabel({
-            points: [points[1], baseMidpoint, points[0]],
-            stroke: GREEN_E
-        });
-    }
-};
-
-var drawSimpleRectangle = function(description) {
-    var x = description.x || 0;
-    var y = description.y || 0;
-    var rotate = description.rotate || 0;
-    var width  = description.width || 1;
-    var height = description.height || 1;
-    var showLabels = description.showLabels || false;
-
-    var points = rotatePoints([x, y], rotate, [
-            [x - width/2, y - height/2],
-            [x - width/2, y + height/2],
-            [x + width/2, y + height/2],
-            [x + width/2, y - height/2]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [
-            null,
-            null,
-            showLabels ? "$len0" : null,
-            showLabels ? "$len0" : null
-            ],
-        ticks: description.ticks,
-        fill: GREEN_D,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-};
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
 
 drawSimpleRectangle({
     x: 5.5,
@@ -144,12 +51,88 @@ drawSimpleTriangle({
     centerOffset: 0
 });
 
+/* Helper functions for drawing simple polygons            */
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-function setup() {
-    var scales = _.map(range, function(extent) {
-        return Perseus.Util.scaleFromExtent(extent, size);
+function rotatePoints(center, angle, points) {
+    return _.map(points, function(pt) {
+        return rotatePoint(pt, angle, center);
     });
-    init({range: range, scale: _.min(scales)});
 }
 
+function drawSimpleTriangle(description) {
+    var x      = description.x || 0;
+    var y      = description.y || 0;
+    var rotate = description.rotate || 0;
+    var base   = description.base || 1;
+    var height = description.height || triangleHeight * base;
+    var showLabels = description.showLabels || false;
+    var centerOffset = description.centerOffset === undefined ?
+            height/3 :
+            description.centerOffset;
+
+    var points = rotatePoints([x, y], rotate, [
+        [x - base/2, y - centerOffset],
+        [x, y + height - centerOffset],
+        [x + base/2, y - centerOffset]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [null, null, showLabels ? "$len0" : null],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+    if (showLabels) {
+        baseMidpoint = lineMidpoint([points[0], points[2]]);
+        drawSegment({
+            points: [points[1], baseMidpoint],
+            dashed: true,
+            stroke: GREEN_E
+        });
+        var midpoint=[(points[1][0]+baseMidpoint[0])/2,(points[1][1]+baseMidpoint[1])/2];
+        var dist=round(sqrt(pow(points[1][0]-baseMidpoint[0],2)+pow(points[1][1]-baseMidpoint[1],2))*100)/100;
+        var labelDirections=["left","above left","above","above right","right"];
+        var direction=atan((points[1][1]-baseMidpoint[1])/(points[1][0]-baseMidpoint[0]))/Math.PI*180;
+        label(midpoint,dist,labelDirections[floor((112.5-direction)/45)]);
+        drawAngleLabel({
+            points: [points[1], baseMidpoint, points[0]],
+            stroke: GREEN_E
+        });
+    }
+}
+
+function drawSimpleRectangle(description) {
+    var x = description.x || 0;
+    var y = description.y || 0;
+    var rotate = description.rotate || 0;
+    var width  = description.width || 1;
+    var height = description.height || 1;
+    var showLabels = description.showLabels || false;
+
+    var points = rotatePoints([x, y], rotate, [
+            [x - width/2, y - height/2],
+            [x - width/2, y + height/2],
+            [x + width/2, y + height/2],
+            [x + width/2, y - height/2]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [
+            null,
+            null,
+            showLabels ? "$len0" : null,
+            showLabels ? "$len0" : null
+            ],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+}
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 </script>

--- a/templates/24_triangular_prism_net.html
+++ b/templates/24_triangular_prism_net.html
@@ -1,89 +1,8 @@
 <script type="text/graphie" data-use-simple="true" data-range="[[0, 4], [0, 6.5]]" data-title="24. Triangular Prism Net">
-/* Helper functions for drawing simple polygons            */
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 var triangleHeight = sqrt(3)/2;
 var triangleOffset = triangleHeight/3;
 var triangleBuffer = 1/2 - triangleOffset;
-
-var rotatePoints = function(center, angle, points) {
-    return _.map(points, function(pt) {
-        return rotatePoint(pt, angle, center);
-    });
-};
-
-var drawSimpleTriangle = function(description) {
-    var x      = description.x || 0;
-    var y      = description.y || 0;
-    var rotate = description.rotate || 0;
-    var base   = description.base || 1;
-    var height = description.height || triangleHeight * base;
-    var showLabels = description.showLabels || false;
-    var centerOffset = description.centerOffset === undefined ?
-            height/3 :
-            description.centerOffset;
-
-    var points = rotatePoints([x, y], rotate, [
-        [x - base/2, y - centerOffset],
-        [x, y + height - centerOffset],
-        [x + base/2, y - centerOffset]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [null, null, showLabels ? "$len0" : null],
-        ticks: description.ticks,
-        fill: GREEN_D,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-    if (showLabels) {
-        baseMidpoint = lineMidpoint([points[0], points[2]]);
-        drawSegment({
-            points: [points[1], baseMidpoint],
-            dashed: true,
-            sideLabel: "$len0",
-            stroke: GREEN_E
-        });
-        drawAngleLabel({
-            points: [points[1], baseMidpoint, points[0]],
-            stroke: GREEN_E
-        });
-    }
-};
-
-var drawSimpleRectangle = function(description) {
-    var x = description.x || 0;
-    var y = description.y || 0;
-    var rotate = description.rotate || 0;
-    var width  = description.width || 1;
-    var height = description.height || 1;
-    var showLabels = description.showLabels || false;
-
-    var points = rotatePoints([x, y], rotate, [
-            [x - width/2, y - height/2],
-            [x - width/2, y + height/2],
-            [x + width/2, y + height/2],
-            [x + width/2, y - height/2]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [
-            null,
-            null,
-            showLabels ? "$len0" : null,
-            showLabels ? "$len0" : null
-        ],
-        ticks: description.ticks,
-        fill: GREEN_D,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-};
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
 
 var showLabels = false;
 
@@ -140,17 +59,89 @@ drawSimpleRectangle({
     ticks: [2, 1, 2, 1]
 });
 
-/* a rectangle attached to the right side of the lower triangle  */
-/*
-var rightRectCenter = rotatePoint(lowerRectCenter, 120, lowerTriangleCenter);
-drawSimpleRectangle({
-    x: rightRectCenter[0],
-    y: rightRectCenter[1],
-    width: 1,
-    height: 2,
-    rotate: 120,
-    showLabels: showLabels,
-    ticks: [2, 1, 2, 1]
-});
-*/
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+/* Helper functions for drawing simple polygons            */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+function rotatePoints(center, angle, points) {
+    return _.map(points, function(pt) {
+        return rotatePoint(pt, angle, center);
+    });
+}
+
+function drawSimpleTriangle(description) {
+    var x      = description.x || 0;
+    var y      = description.y || 0;
+    var rotate = description.rotate || 0;
+    var base   = description.base || 1;
+    var height = description.height || triangleHeight * base;
+    var showLabels = description.showLabels || false;
+    var centerOffset = description.centerOffset === undefined ?
+            height/3 :
+            description.centerOffset;
+
+    var points = rotatePoints([x, y], rotate, [
+        [x - base/2, y - centerOffset],
+        [x, y + height - centerOffset],
+        [x + base/2, y - centerOffset]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [null, null, showLabels ? "$len0" : null],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+    if (showLabels) {
+        baseMidpoint = lineMidpoint([points[0], points[2]]);
+        drawSegment({
+            points: [points[1], baseMidpoint],
+            dashed: true,
+            stroke: GREEN_E
+        });
+        var midpoint=[(points[1][0]+baseMidpoint[0])/2,(points[1][1]+baseMidpoint[1])/2];
+        var dist=sqrt(pow(points[1][0]-baseMidpoint[0],2)+pow(points[1][1]-baseMidpoint[1],2));
+        var labelDirections=["left","above left","above","above right","right"];
+        var direction=atan((points[1][1]-baseMidpoint[1])/(points[1][0]-baseMidpoint[0]))/Math.PI*180;
+        label(midpoint,dist,labelDirections[floor((112.5-direction)/45)]);        
+        drawAngleLabel({
+            points: [points[1], baseMidpoint, points[0]],
+            stroke: GREEN_E
+        });
+    }
+}
+
+function drawSimpleRectangle(description) {
+    var x = description.x || 0;
+    var y = description.y || 0;
+    var rotate = description.rotate || 0;
+    var width  = description.width || 1;
+    var height = description.height || 1;
+    var showLabels = description.showLabels || false;
+
+    var points = rotatePoints([x, y], rotate, [
+            [x - width/2, y - height/2],
+            [x - width/2, y + height/2],
+            [x + width/2, y + height/2],
+            [x + width/2, y - height/2]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [
+            null,
+            null,
+            showLabels ? "$len0" : null,
+            showLabels ? "$len0" : null
+        ],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+}
 </script>

--- a/templates/25_tetrahedron_net.html
+++ b/templates/25_tetrahedron_net.html
@@ -1,57 +1,7 @@
 <script type="text/graphie" data-use-simple="true" data-range="[[0, 6], [0, 5]]" data-title="25. Tetrahedron Net">
-/* Helper functions for drawing simple polygons            */
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 var triangleHeight = sqrt(3)/2;
 var triangleOffset = triangleHeight/3;
 var triangleBuffer = 1/2 - triangleOffset;
-
-var rotatePoints = function(center, angle, points) {
-    return _.map(points, function(pt) {
-        return rotatePoint(pt, angle, center);
-    });
-};
-
-var drawSimpleTriangle = function(description) {
-    var x      = description.x || 0;
-    var y      = description.y || 0;
-    var rotate = description.rotate || 0;
-    var base   = description.base || 1;
-    var height = description.height || triangleHeight * base;
-    var showLabels = description.showLabels || false;
-    var centerOffset = description.centerOffset === undefined ?
-            height/3 :
-            description.centerOffset;
-
-    var points = rotatePoints([x, y], rotate, [
-        [x - base/2, y - centerOffset],
-        [x, y + height - centerOffset],
-        [x + base/2, y - centerOffset]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [null, null, showLabels ? "$len0" : null],
-        ticks: description.ticks,
-        fill: GREEN_D,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-    if (showLabels) {
-        baseMidpoint = lineMidpoint([points[0], points[2]]);
-        drawSegment({
-            points: [points[1], baseMidpoint],
-            dashed: true,
-            sideLabel: "$len0",
-            stroke: GREEN_E
-        });
-        drawAngleLabel({
-            points: [points[1], baseMidpoint, points[0]],
-            stroke: GREEN_E
-        });
-    }
-};
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 
 /* since our triangles have side length 2 */
@@ -87,4 +37,88 @@ drawSimpleTriangle({
     rotate: 180,
     ticks: [1, 1, 1]
 });
+
+/* Helper functions for drawing simple polygons            */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+function rotatePoints(center, angle, points) {
+    return _.map(points, function(pt) {
+        return rotatePoint(pt, angle, center);
+    });
+}
+
+function drawSimpleTriangle(description) {
+    var x      = description.x || 0;
+    var y      = description.y || 0;
+    var rotate = description.rotate || 0;
+    var base   = description.base || 1;
+    var height = description.height || triangleHeight * base;
+    var showLabels = description.showLabels || false;
+    var centerOffset = description.centerOffset === undefined ?
+            height/3 :
+            description.centerOffset;
+
+    var points = rotatePoints([x, y], rotate, [
+        [x - base/2, y - centerOffset],
+        [x, y + height - centerOffset],
+        [x + base/2, y - centerOffset]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [null, null, showLabels ? "$len0" : null],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+    if (showLabels) {
+        baseMidpoint = lineMidpoint([points[0], points[2]]);
+        drawSegment({
+            points: [points[1], baseMidpoint],
+            dashed: true,
+            stroke: GREEN_E
+        });
+        var midpoint=[(points[1][0]+baseMidpoint[0])/2,(points[1][1]+baseMidpoint[1])/2];
+        var dist=round(sqrt(pow(points[1][0]-baseMidpoint[0],2)+pow(points[1][1]-baseMidpoint[1],2))*100)/100;
+        var labelDirections=["left","above left","above","above right","right"];
+        var direction=atan((points[1][1]-baseMidpoint[1])/(points[1][0]-baseMidpoint[0]))/Math.PI*180;
+        label(midpoint,dist,labelDirections[floor((112.5-direction)/45)]);
+        drawAngleLabel({
+            points: [points[1], baseMidpoint, points[0]],
+            stroke: GREEN_E
+        });
+    }
+}
+
+function drawSimpleRectangle(description) {
+    var x = description.x || 0;
+    var y = description.y || 0;
+    var rotate = description.rotate || 0;
+    var width  = description.width || 1;
+    var height = description.height || 1;
+    var showLabels = description.showLabels || false;
+
+    var points = rotatePoints([x, y], rotate, [
+            [x - width/2, y - height/2],
+            [x - width/2, y + height/2],
+            [x + width/2, y + height/2],
+            [x + width/2, y - height/2]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [
+            null,
+            null,
+            showLabels ? "$len0" : null,
+            showLabels ? "$len0" : null
+            ],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+}
 </script>

--- a/templates/25_tetrahedron_net.html
+++ b/templates/25_tetrahedron_net.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[0, 6], [0, 5]]" data-title="25. Tetrahedron Net">
+<script type="text/graphie" data-use-simple="true" data-range="[[0.9, 5.1], [0.6, 4.2]]" data-title="25. Tetrahedron Net">
 var triangleHeight = sqrt(3)/2;
 var triangleOffset = triangleHeight/3;
 var triangleBuffer = 1/2 - triangleOffset;

--- a/templates/26_octahedron_net.html
+++ b/templates/26_octahedron_net.html
@@ -1,58 +1,7 @@
-<script type="text/graphie" data-use-simple="true" data-range="[[0, 6], [0, 8]]" data-title="26. Octahedron Net">
-/* Helper functions for drawing simple polygons            */
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+<script type="text/graphie" data-use-simple="true" data-range="[[0.9, 5.1], [0.5, 7.5]]" data-title="26. Octahedron Net">
 var triangleHeight = sqrt(3)/2;
 var triangleOffset = triangleHeight/3;
 var triangleBuffer = 1/2 - triangleOffset;
-
-var rotatePoints = function(center, angle, points) {
-    return _.map(points, function(pt) {
-        return rotatePoint(pt, angle, center);
-    });
-};
-
-var drawSimpleTriangle = function(description) {
-    var x      = description.x || 0;
-    var y      = description.y || 0;
-    var rotate = description.rotate || 0;
-    var base   = description.base || 1;
-    var height = description.height || triangleHeight * base;
-    var showLabels = description.showLabels || false;
-    var centerOffset = description.centerOffset === undefined ?
-            height/3 :
-            description.centerOffset;
-
-    var points = rotatePoints([x, y], rotate, [
-        [x - base/2, y - centerOffset],
-        [x, y + height - centerOffset],
-        [x + base/2, y - centerOffset]
-    ]);
-
-    drawPolygon({
-        points: points,
-        angleLabels: [],
-        sideLabels: [null, null, showLabels ? "$len0" : null],
-        ticks: description.ticks,
-        fill: GREEN_D,
-        fillOpacity: 0.2,
-        stroke: GREEN_E
-    });
-    if (showLabels) {
-        baseMidpoint = lineMidpoint([points[0], points[2]]);
-        drawSegment({
-            points: [points[1], baseMidpoint],
-            dashed: true,
-            sideLabel: "$len0",
-            stroke: GREEN_E
-        });
-        drawAngleLabel({
-            points: [points[1], baseMidpoint, points[0]],
-            stroke: GREEN_E
-        });
-    }
-};
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
 
 /* since our triangles have side length 2 */
 var offset = 2 * triangleOffset;
@@ -121,4 +70,88 @@ drawSimpleTriangle({
     rotate: 0,
     ticks: [1, 1, 1]
 });
+
+/* Helper functions for drawing simple polygons            */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+function rotatePoints(center, angle, points) {
+    return _.map(points, function(pt) {
+        return rotatePoint(pt, angle, center);
+    });
+}
+
+function drawSimpleTriangle(description) {
+    var x      = description.x || 0;
+    var y      = description.y || 0;
+    var rotate = description.rotate || 0;
+    var base   = description.base || 1;
+    var height = description.height || triangleHeight * base;
+    var showLabels = description.showLabels || false;
+    var centerOffset = description.centerOffset === undefined ?
+            height/3 :
+            description.centerOffset;
+
+    var points = rotatePoints([x, y], rotate, [
+        [x - base/2, y - centerOffset],
+        [x, y + height - centerOffset],
+        [x + base/2, y - centerOffset]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [null, null, showLabels ? "$len0" : null],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+    if (showLabels) {
+        baseMidpoint = lineMidpoint([points[0], points[2]]);
+        drawSegment({
+            points: [points[1], baseMidpoint],
+            dashed: true,
+            stroke: GREEN_E
+        });
+        var midpoint=[(points[1][0]+baseMidpoint[0])/2,(points[1][1]+baseMidpoint[1])/2];
+        var dist=round(sqrt(pow(points[1][0]-baseMidpoint[0],2)+pow(points[1][1]-baseMidpoint[1],2))*100)/100;
+        var labelDirections=["left","above left","above","above right","right"];
+        var direction=atan((points[1][1]-baseMidpoint[1])/(points[1][0]-baseMidpoint[0]))/Math.PI*180;
+        label(midpoint,dist,labelDirections[floor((112.5-direction)/45)]);
+        drawAngleLabel({
+            points: [points[1], baseMidpoint, points[0]],
+            stroke: GREEN_E
+        });
+    }
+}
+
+function drawSimpleRectangle(description) {
+    var x = description.x || 0;
+    var y = description.y || 0;
+    var rotate = description.rotate || 0;
+    var width  = description.width || 1;
+    var height = description.height || 1;
+    var showLabels = description.showLabels || false;
+
+    var points = rotatePoints([x, y], rotate, [
+            [x - width/2, y - height/2],
+            [x - width/2, y + height/2],
+            [x + width/2, y + height/2],
+            [x + width/2, y - height/2]
+    ]);
+
+    drawPolygon({
+        points: points,
+        angleLabels: [],
+        sideLabels: [
+            null,
+            null,
+            showLabels ? "$len0" : null,
+            showLabels ? "$len0" : null
+            ],
+        ticks: description.ticks,
+        fill: GREEN_D,
+        fillOpacity: 0.2,
+        stroke: GREEN_E
+    });
+}
 </script>

--- a/templates/27_box_plot.html
+++ b/templates/27_box_plot.html
@@ -1,6 +1,4 @@
 <script type="text/graphie" data-title="27. Box Plot">
-// For an interactive example, see:
-// khan-exercises/exercises/creating_box_and_whisker_plots.html
 
 var axisLabel = "Axis label";
 var color = BLUE_D;
@@ -30,7 +28,7 @@ var yMin = axisLabel ? -4.5 : -3.5;
 
 init({
     range: [xrange, [ yMin, 1.5 ]],
-    scale: _.min([30, Perseus.Util.scaleFromExtent(xrange, 480)])
+    scale: _.min([30, Perseus.Util.scaleFromExtent(xrange, 320)])
 });
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -44,11 +42,14 @@ var denormalize = function(position) {
 };
 
 /* Draw the number line */
+var labelStep=Perseus.Util.tickStepFromExtent([numberLineMin,numberLineMax],320);
 line([ 0, -2 ], [ numberLineTickCount, -2 ]);
 for (tick = 0; tick <= numberLineTickCount; tick+=1) {
     var tickValue = denormalize(tick);
     line([ tick, -1.75 ], [ tick, -2.25 ]);
-    label([ tick, -2.25 ], roundTo(1, tickValue), "below");
+    if((tickValue-numberLineMin)%labelStep===0){
+        label([ tick, -2.25 ], roundTo(1, tickValue), "below");
+    }
 }
 
 var nq0 = normalize(q0);
@@ -91,6 +92,6 @@ for (var i=0; i < outliers.length; i++) {
 
 // axis label
 if (axisLabel) {
-    label([numberLineTickCount/2, -3.5], axisLabel, "below", false, {"font-weight": "bold"});
+    label([numberLineTickCount/2, -3.4], axisLabel, "below", false, {"font-weight": "bold"});
 }
 </script>

--- a/templates/28_dot_plot.html
+++ b/templates/28_dot_plot.html
@@ -3,7 +3,7 @@ var axisLabel = "Axis label";
 
 /* Variables */
 var min = 0;            // number line start
-var max = 10;           // number line end
+var max = 7;           // number line end
 
 var labelInterval = 1;  // interval at which line will be labeled
 var tickInterval = 1/4; // interval at which ticks will be drawn
@@ -20,8 +20,6 @@ var data = {
     4.50: 6,
     4.75: 2,
     6.00: 2,
-    8.25: 1,
-    9.50: 2
 };
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -52,7 +50,7 @@ var yRange = [yMin, _.max(data) * ySpacing];
 /* Prevent width from exceeding 480 pixels */
 init({
     range: [xRange, yRange],
-    scale: _.min([30, Perseus.Util.scaleFromExtent(xRange, 480)])
+    scale: _.min([30, Perseus.Util.scaleFromExtent(xRange, 320)])
 });
 
 var normalize = function(number) {

--- a/templates/29_polar_plot.html
+++ b/templates/29_polar_plot.html
@@ -2,7 +2,7 @@
 plotPolar(function(theta) {
     // Write down the function you want to plot here
     return 5 * cos(10 * cos(theta));
-}, [0, 2*PI], {
+}, [0, 2*PI], { //Note that theta is in radians
     stroke: BLUE_D,
     strokeWidth: 3
 });

--- a/templates/30_fraction_pie.html
+++ b/templates/30_fraction_pie.html
@@ -51,7 +51,7 @@ function fractionPie(options) {
             } else {
                 arc(center, r, startAngle, endAngle, true);
             }
-        })
+        });
 
         startAngle += slice[0];
     });

--- a/templates/35_drawing_helper_functions.html
+++ b/templates/35_drawing_helper_functions.html
@@ -1,9 +1,9 @@
 <script type="text/graphie" data-title="35. Drawing helper functions">
 /* The X and Y ranges of this canvas */
-var range = [[-1, 10], [-2, 8]];
+var range = [[0.9, 6.1], [0.9, 5.1]];
 
 /* The output's largest side is limited to this many pixels */
-var size = 400;
+var size = 320;
 
 setup();
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/templates/38_riemann_sums.html
+++ b/templates/38_riemann_sums.html
@@ -21,7 +21,6 @@ plot(function(x) {
     return 0.03*(x+5)*(x+2)*(x-3)*(x-6);
 }, X_RANGE);
 
-
 //////////////////////////////////////////////////////////////
 function riemann(fn, domain, divisions, kind, color) {
     var x = domain[0];
@@ -32,17 +31,16 @@ function riemann(fn, domain, divisions, kind, color) {
             fill: color,
             stroke: color,
             opacity: 0.3
-        }, function() {
-            path([[x, 0], [x, fn(x + offset)], [x + step, fn(x + offset)], [x + step, 0], true]);
         });
+        path([[x, 0], [x, fn(x + offset)], [x + step, fn(x + offset)], [x + step, 0], true]);
+        
         style({
             fill: "none",
             stroke: color,
             strokeWidth: 1,
             opacity: 1
-        }, function() {
-            path([[x, 0], [x, fn(x + offset)], [x + step, fn(x + offset)], [x + step, 0], true]);
         });
+        path([[x, 0], [x, fn(x + offset)], [x + step, fn(x + offset)], [x + step, 0], true]);
         x += step;
     }
 }

--- a/templates/39_bar_plot.html
+++ b/templates/39_bar_plot.html
@@ -1,10 +1,10 @@
 <script type="text/graphie" data-title="39. Bar Plot">
 /* Data to plot. Should be numbers indicating the height of each bucket. */
 var data = [
-    5,
-    3,
-    9,
-    6
+    ["Group<br>A", 5], //<br> splits the label over 2 lines
+    ["Group<br>B", 3],
+    ["Group<br>C", 9],
+    ["Group<br>D", 6]
 ];
 
 /* y-parameters */
@@ -17,15 +17,15 @@ var minBucket = 2;
 var maxBucket = 10;
 
 /* Graph styles */
-var xLabel = "X values";
+var xLabel = "X categories";
 var yLabel = "Y values";
 var title = "Graph title";
 
 // Bar plots typically use light colors
-var color = GREEN_B;
-var outline = GREEN_E;
+var colors = [GREEN_B, PURPLE_B, TEAL_B, MAROON_B];
+var outlines = [GREEN_E, PURPLE_E, TEAL_E, MAROON_E];
 var tickHeight = 6;
-var plotDimensions = [380, 300];
+var plotDimensions = [240, 180];
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 /* Setup the canvas                                       */
@@ -34,7 +34,7 @@ var plotDimensions = [380, 300];
 var numBins = _.size(data);
 var bucketSize = (maxBucket - minBucket) / numBins;
 var barPad = 0.15;
-var barWidth = 1;
+var barWidth = 1 - 2 * barPad;
 var barHalfWidth = barWidth / 2;
 var dimX = numBins + 2 * barPad;
 
@@ -45,10 +45,10 @@ var dimY = Math.ceil((yMax - yMin) / yScale) * yScale;
 var scale = _.map([dimX, dimY], function (dim, i) {
     return plotDimensions[i] / dim;
 });
-var padX = 25 / scale[0];
-var padY = 25 / scale[1];
+var padX = 20 / scale[0];
+var padY = 20 / scale[1];
 var padYTop = title ? padY * 3 : padY;
-var range = [[-3 * padX, dimX + padX], [-3 * padY, dimY + padYTop]];
+var range = [[-3 * padX, dimX], [-3.5 * padY, dimY + padYTop]];
 
 // Initialize graph
 init({
@@ -60,25 +60,29 @@ init({
 
 /* Begin plotting. First, plot the axis ticks, then the bars, then the  */
 /* axes. This ensures proper layout on the z-axis.                      */
+var labelStep=Perseus.Util.tickStepFromExtent([0,dimY],plotDimensions[1]);
 for (var y = 0; y <= dimY; y += yScale) {
     style({opacity: 1.0});
-    label(
-        [0, y],
-        roundToApprox(y, 2),
-        "left",
-        /* isTeX */ true /* for the \approx symbol */
-    );
+    if(y%labelStep===0){
+        label(
+            [0, y],
+            roundToApprox(y, 2),
+            "left",
+            /* isTeX */ true /* for the \approx symbol */
+        );
+    }
     style({stroke: "#000", strokeWidth: 1, opacity: 0.3});
     line([0, y], [dimX, y]);
 }
 
 // Plot each bar with its label
 _.each(data, function(item, i) {
-    var count = item;
+    var count = item[1];
+    var category = item[0];
     var x = 0.5 + i + barPad;
 
     // Cycle through colors
-    style({opacity: 1, strokeWidth: 2, stroke: outline, fill: color});
+    style({opacity: 1, strokeWidth: 2, stroke: outlines[i%colors.length], fill: colors[i%colors.length]});
 
     // Plot bar
     path([
@@ -87,21 +91,14 @@ _.each(data, function(item, i) {
             [x + barHalfWidth, count],
             [x + barHalfWidth, 0]
         ]);
-});
-
-// Plot each bar with its label
-_.times(numBins + 1, function(i) {
-    var x = i + barPad;
-    var l = (i * bucketSize) + minBucket;
-
-    // Plot the label tick mark
-    style({stroke: "#000", strokeWidth: 2, opacity: 1.0});
+        
+    // Plot bar label (below axis)
     var scaledTickHeight = tickHeight / scale[1];
+    style({stroke: "#000", strokeWidth: 2, opacity: 1.0});
     line([x, -scaledTickHeight], [x, 0]);
-
-    // Draw the label
-    label([x, -0.1], l, "below", true);
+    label([x, 0], "<center>"+category+"</center>", "below", false);
 });
+
 
 // Add axes (after drawing boxes)
 style({stroke: "#000", strokeWidth: 2, opacity: 1.0});
@@ -117,12 +114,12 @@ if (title) {
 }
 
 // Add axis labels
-label([dimX / 2, -35 / scale[1]],
+label([dimX / 2, -45 / scale[1]],
     xLabel,
     "below", false)
     .css("font-weight", "bold");
 
-label([-60 / scale[0], dimY / 2],
+label([-45 / scale[0], dimY / 2],
     yLabel,
     "center", false)
     .css("font-weight", "bold")

--- a/templates/39_bar_plot.html
+++ b/templates/39_bar_plot.html
@@ -1,5 +1,5 @@
 <script type="text/graphie" data-title="39. Bar Plot">
-/* Data to plot. Should be numbers indicating the height of each bucket. */
+/* Data to plot. Should be numbers indicating the height of each category. */
 var data = [
     ["Group<br>A", 5], //<br> splits the label over 2 lines
     ["Group<br>B", 3],
@@ -11,10 +11,6 @@ var data = [
 var yMin = 0;
 var yMax = 10;
 var yScale = 1;
-
-/* bucket parameters */
-var minBucket = 2;
-var maxBucket = 10;
 
 /* Graph styles */
 var xLabel = "X categories";
@@ -32,7 +28,6 @@ var plotDimensions = [240, 180];
 
 // Calculate x-parameters
 var numBins = _.size(data);
-var bucketSize = (maxBucket - minBucket) / numBins;
 var barPad = 0.15;
 var barWidth = 1 - 2 * barPad;
 var barHalfWidth = barWidth / 2;

--- a/templates/40_shade_area_between_curves.html
+++ b/templates/40_shade_area_between_curves.html
@@ -1,5 +1,4 @@
 <script type="text/graphie" data-use-grid="true" data-title="40. Shade area between curves">
-
 var fn1 = function(x) {
     // Define first function here
     return - 0.5 * x * x + 3.0 * x - 2.0;
@@ -29,13 +28,14 @@ plot(fn2, X_RANGE);
 
 plot(fn1,
     [-2, 4], // <-- x-range to shade
-    false, true, fn2,
-    // Styling for shaded region function
+    false, // Don't swap axes, because it doesn't work with shading between functions
+    true, //Do shade between functions
+    fn2,
+    // Styling for shaded region between functions
     {
         stroke: "none",
         fill: BLUE_D,
         fillOpacity: 0.3
     }
 );
-
 </script>

--- a/templates/40a_shade_horizontal_area_between_curves.html
+++ b/templates/40a_shade_horizontal_area_between_curves.html
@@ -1,0 +1,40 @@
+<script type="text/graphie" data-use-grid="true" data-title="40a. Shade horizontal area between curves">
+var fn1 = function(t) {
+    // Define first function here
+    return [- 0.5 * t * t + 3.0 * t - 2.0,t];
+};
+
+var fn2 = function(t) {
+    // Define second function here
+    return [t * t * t - 2.5 * t * t + 4 * t - 1.0,t];
+};
+
+// Styling for first function
+style({
+    stroke: BLUE_D,
+    fill: "none",
+    strokeWidth: 3
+});
+
+plotParametric(fn1, Y_RANGE);
+
+// Styling for second function
+style({
+    stroke: RED_D,
+    fill: "none"
+});
+
+plotParametric(fn2, Y_RANGE);
+
+plotParametric(fn1,
+    [-2, 4], // <-- y-range to shade
+    true, //Do shade between functions
+    fn2,
+    // Styling for shaded region between functions
+    {
+        stroke: "none",
+        fill: BLUE_D,
+        fillOpacity: 0.3
+    }
+);
+</script>

--- a/templates/42_slope_field.html
+++ b/templates/42_slope_field.html
@@ -1,4 +1,4 @@
-<script type="text/graphie" data-use-grid="true" data-title="42. Slope field">
+<script type="text/graphie" data-use-nonsquare="true" data-title="42. Slope field">
 var diffEq = function(x, y) {
     // Define the differential equation here
     return -x / y;

--- a/templates/43_histogram.html
+++ b/templates/43_histogram.html
@@ -22,7 +22,7 @@ var yLabel = "Y values";
 // Bar plots typically use light colors
 var colors = [BLUE_C, RED_C, GREEN_C];
 var tickHeight = 6;
-var plotDimensions = [380, 300];
+var plotDimensions = [240,180];
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 /* Setup the canvas                                       */
@@ -42,15 +42,17 @@ var dimY = Math.ceil((yMax - yMin) / yScale) * yScale;
 var scale = _.map([dimX, dimY], function (dim, i) {
     return plotDimensions[i] / dim;
 });
-var padX = 25 / scale[0];
-var padY = 25 / scale[1];
-var range = [[-3 * padX, dimX + padX], [-3 * padY, dimY + padY]];
+var padX = 20 / scale[0];
+var padY = 20 / scale[1];
+var range = [[-3 * padX, dimX], [-3 * padY, dimY + padY]];
 
 // Initialize graph
 init({
     range: range,
     scale: scale
 });
+var labelStep=Perseus.Util.tickStepFromExtent([yMin,yMax],plotDimensions[1]);
+
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 
@@ -58,12 +60,14 @@ init({
 /* axes. This ensures proper layout on the z-axis.                      */
 for (var y = 0; y <= dimY; y += yScale) {
     style({opacity: 1.0});
-    label(
-        [0, y],
-        roundToApprox(y, 2),
-        "left",
-        /* isTeX */ true /* for the \approx symbol */
-    );
+    if(y%labelStep===0){
+        label(
+            [0, y],
+            roundToApprox(y, 2),
+            "left",
+            /* isTeX */ true /* for the \approx symbol */
+        );
+    }
     style({stroke: "#000", strokeWidth: 1, opacity: 0.3});
     line([0, y], [dimX, y]);
 }
@@ -112,9 +116,10 @@ label([dimX / 2, -35 / scale[1]],
     "below", false)
     .css("font-weight", "bold");
 
-label([-60 / scale[0], dimY / 2],
+label([-45 / scale[0], dimY / 2],
     yLabel,
     "center", false)
     .css("font-weight", "bold")
     .css("transform", "rotate(-90deg)");
+
 </script>

--- a/templates/44_segmented_bar_graph.html
+++ b/templates/44_segmented_bar_graph.html
@@ -3,9 +3,9 @@
 label and a list of values.  List of values
 should add to 100, or whatever yMax happens to be*/
 var data = [
-    ['X Category 1', [20, 30, 10, 40]],
-    ['X Category 2', [30, 60, 0, 10]],
-    ['X Category 3', [40, 20, 20, 20]],
+    ['X group<br>1', [20, 30, 10, 40]], //<br> splits the label over 2 lines
+    ['X group<br>2', [30, 60, 0, 10]],
+    ['X group<br>3', [40, 20, 20, 20]],
 ];
 
 /* y-parameters */
@@ -19,11 +19,10 @@ var xLabel = "X Label";
 var yLabel = "Y Label";
 var title = "Name of graph";
 var tickHeight = 6;
-var plotDimensions = [380, 300];
+var plotDimensions = [240,180];
 
 /* Second category type information */
-// Bar plots typically use light colors
-// Length both these lists should match length of 
+// Length of both these lists should match length of 
 // values in second coordinate of each data point
 var colors = [
     BLUE_E, 
@@ -32,10 +31,10 @@ var colors = [
     BLUE_B
 ];
 var YCategoryNames = [
-    "Y Category 1",
-    "Y Category 2",
-    "Y Category 3",
-    "Y Category 4"   
+    "Y group 1",
+    "Y group 2",
+    "Y group 3",
+    "Y group 4"   
 ];
 var yCategoryLabelSpacing = 10;
 var squareWidth = 15;
@@ -43,6 +42,11 @@ var squareWidth = 15;
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 /* Setup the canvas                                       */
+
+_.each(data,function(item){
+    item[1].reverse();
+    });
+YCategoryNames.reverse();
 
 // Calculate x-parameters
 var numBins = _.size(data);
@@ -58,13 +62,13 @@ var dimY = Math.ceil((yMax - yMin) / yScale) * yScale;
 var scale = _.map([dimX, dimY], function (dim, i) {
     return plotDimensions[i] / dim;
 });
-var padX = 25 / scale[0];
-var padY = 25 / scale[1];
+var padX = 20 / scale[0];
+var padY = 20 / scale[1];
 var padYTop = title ? padY * 3 : padY;
-var legandSpace = 120 / scale[1];
+var legendSpace = 120 / scale[1];
 var range = [
-    [-3 * padX, dimX + padX], 
-    [-3 * padY - legandSpace, dimY + padYTop],
+    [-3 * padX, dimX], 
+    [-3 * padY - legendSpace, dimY + padYTop],
 ];
 
 // Initialize graph
@@ -104,7 +108,7 @@ _.each(data, function(item, i) {
     var scaledTickHeight = tickHeight / scale[1];
     style({stroke: "#000", strokeWidth: 2, opacity: 1.0});
     line([x, -scaledTickHeight], [x, 0]);
-    label([x, 0], category, "below", false);
+    label([x, 0], "<center>"+category+"</center>", "below", false);
 
     // Plot bar
     var lastY = 0;
@@ -135,23 +139,23 @@ if (title) {
 }
 
 // Add axis labels
-label([dimX / 2, -35 / scale[1]],
+label([dimX / 2, -45 / scale[1]],
     xLabel,
     "below", false)
     .css("font-weight", "bold");
 
-label([-60 / scale[0], dimY / 2],
+label([-55 / scale[0], dimY / 2],
     yLabel,
     "center", false)
     .css("font-weight", "bold")
     .css("transform", "rotate(-90deg)");
     
     
-/* Add Legand */
+/* Add Legend */
 var xStart = 0; // modify to shift legend right/left
 var yStart = 0; // modify to shift legend up/down
 _.each(YCategoryNames, function(name, i){
-    var y = -legandSpace - (padY * 2) + yCategoryLabelSpacing * i;
+    var y = -legendSpace - (padY * 2) + yCategoryLabelSpacing * i;
     var color = colors[i % colors.length];
     drawPolygon({points:[
             [xStart + 0, yStart + y + squareWidth / scale[1] / 2],

--- a/templates/45_side_by_side_bar_graph.html
+++ b/templates/45_side_by_side_bar_graph.html
@@ -3,9 +3,9 @@
 label and a list of values.  List of values
 should add to 100, or whatever yMax happens to be*/
 var data = [
-    ['X Category 1', [20, 30, 10, 40]],
-    ['X Category 2', [30, 60, 0, 10]],
-    ['X Category 3', [40, 20, 20, 20]],
+    ['X class<br>1', [20, 30, 10, 40]], //<br> splits the label over 2 lines
+    ['X class<br>2', [30, 60, 0, 10]],
+    ['X class<br>3', [40, 20, 20, 20]],
 ];
 
 /* y-parameters */
@@ -19,7 +19,7 @@ var xLabel = "X Label";
 var yLabel = "Y Label";
 var title = "Name of graph";
 var tickHeight = 6;
-var plotDimensions = [380, 300];
+var plotDimensions = [240,180];
 
 /* Second category type information */
 // Bar plots typically use light colors
@@ -58,13 +58,13 @@ var dimY = Math.ceil((yMax - yMin) / yScale) * yScale;
 var scale = _.map([dimX, dimY], function (dim, i) {
     return plotDimensions[i] / dim;
 });
-var padX = 25 / scale[0];
-var padY = 25 / scale[1];
+var padX = 20 / scale[0];
+var padY = 20 / scale[1];
 var padYTop = title ? padY * 3 : padY;
-var legandSpace = 120 / scale[1];
+var legendSpace = 120 / scale[1];
 var range = [
-    [-3 * padX, dimX + padX], 
-    [-3 * padY - legandSpace, dimY + padYTop],
+    [-3 * padX, dimX], 
+    [-3 * padY - legendSpace, dimY + padYTop],
 ];
 
 // Initialize graph
@@ -104,7 +104,7 @@ _.each(data, function(item, i) {
     var scaledTickHeight = tickHeight / scale[1];
     style({stroke: "#000", strokeWidth: 2, opacity: 1.0});
     line([x, -scaledTickHeight], [x, 0]);
-    label([x, 0], category, "below", false);
+    label([x, 0], "<center>"+category+"</center>", "below", false);
 
     // Plot bar
     var skinnyBarWidth = barWidth/data[0][1].length;
@@ -135,24 +135,25 @@ if (title) {
 }
 
 // Add axis labels
-label([dimX / 2, -35 / scale[1]],
+label([dimX / 2, -45 / scale[1]],
     xLabel,
     "below", false)
     .css("font-weight", "bold");
 
-label([-60 / scale[0], dimY / 2],
+label([-55 / scale[0], dimY / 2],
     yLabel,
     "center", false)
     .css("font-weight", "bold")
     .css("transform", "rotate(-90deg)");
     
     
-/* Add Legand */
+/* Add Legend */
 var xLegend = 0; // modify to shift legend right/left
 var yLegend = 0; // modify to shift legend up/down
+groupNames.reverse();
 _.each(groupNames, function(name, i){
-    var y = -legandSpace - (padY*2) + yCategoryLabelSpacing*i;
-    color = colors[i % colors.length];
+    var y = -legendSpace - (padY*2) + yCategoryLabelSpacing*i;
+    color = colors[groupNames.length-(i % colors.length)-1];
     drawPolygon({points: [
         [xLegend + 0, yLegend + y + squareWidth / scale[1] / 2],
         [xLegend + squareWidth / scale[0], yLegend + y + squareWidth / scale[1] / 2],

--- a/templates/47_parallel_box_plots.html
+++ b/templates/47_parallel_box_plots.html
@@ -54,7 +54,7 @@ var yMin = axisLabel ? -4.5 : -3.5;
 
 init({
     range: [xrange, [ yMin, dataSets.length * 2.8 * boxHeight - boxHeight - 0.5]],
-    scale: _.min([30, Perseus.Util.scaleFromExtent(xrange, 480)])
+    scale: _.min([30, Perseus.Util.scaleFromExtent(xrange, 320)])
 });
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -68,11 +68,14 @@ var denormalize = function(position) {
 };
 
 /* Draw the number line */
+var labelStep=Perseus.Util.tickStepFromExtent([numberLineMin,numberLineMax],320);
 line([ 0, -2 ], [ numberLineTickCount, -2 ]);
 for (tick = 0; tick <= numberLineTickCount; tick+=1) {
     var tickValue = denormalize(tick);
     line([ tick, -1.75 ], [ tick, -2.25 ]);
-    label([ tick, -2.25 ], roundTo(1, tickValue), "below");
+    if((tickValue-numberLineMin)%labelStep===0){
+        label([ tick, -2.25 ], roundTo(1, tickValue), "below");
+    }
 }
 
 for (var i = 0; i < dataSets.length; i++) {
@@ -112,7 +115,7 @@ for (var i = 0; i < dataSets.length; i++) {
     line([nq3, 0 + y], [nq4, 0 + y]);
     
     // draw label
-    label([nmedian, y - boxHeight/2], dataSets[i].name, "below", false, {color: dataSets[i].color, "font-weight": "bold"})
+    label([nmedian, y - boxHeight], dataSets[i].name, "center", false, {color: dataSets[i].color, "font-weight": "bold"});
     
     // draw outliers
     var outliers = dataSets[i].outliers;
@@ -125,4 +128,5 @@ for (var i = 0; i < dataSets.length; i++) {
 if (axisLabel) {
     label([numberLineTickCount/2, -3.4], axisLabel, "below", false, {"font-weight": "bold", "font-size": "16px"});
 }
+
 </script>

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -13,6 +13,7 @@
 <div id="samples">
 <script type="text/graphie" data-title="0. Blank page"></script>
 {% include "01_simple_plot.html" %}
+{% include "01a_simple_plot_SAT.html" %}
 {% include "02_piecewise_function.html" %}
 {% include "03_parametric_plots.html" %}
 {% include "04_triangle_old.html" %}
@@ -53,6 +54,7 @@
 {% include "38_riemann_sums.html" %}
 {% include "39_bar_plot.html" %}
 {% include "40_shade_area_between_curves.html" %}
+{% include "40a_shade_horizontal_area_between_curves.html" %}
 {% include "41_shade_area_bounded_by_polar_curve.html" %}
 {% include "42_slope_field.html" %}
 {% include "43_histogram.html" %}
@@ -111,6 +113,10 @@ keUtilsLoaded.then(function() {
     var simpleSetupPost = $("#simple-setup-post").html();
     var polarSetupPre = $("#polar-setup-pre").html();
     var polarSetupPost = $("#polar-setup-post").html();
+    var satGridSetupPre = $("#sat-grid-setup-pre").html();
+    var satGridSetupPost = $("#sat-grid-setup-post").html();
+    var nonsquareGridSetupPre = $("#nonsquare-grid-setup-pre").html();
+    var nonsquareGridSetupPost = $("#nonsquare-grid-setup-post").html();
     var samples = _.map($samples, function(el, i) {
         var $el = $(el);
         var code = $el.html();
@@ -123,6 +129,12 @@ keUtilsLoaded.then(function() {
         }
         if ($el.data("use-polar")) {
             code = polarSetupPre + code + polarSetupPost;
+        }
+        if ($el.data("use-SAT")) {
+            code = satGridSetupPre + code + satGridSetupPost;
+        }
+        if ($el.data("use-nonsquare")) {
+            code = nonsquareGridSetupPre + code + nonsquareGridSetupPost;
         }
         var sample = {
             title: $el.data("title"),

--- a/templates/setup_templates.html
+++ b/templates/setup_templates.html
@@ -8,8 +8,9 @@ var Y_RANGE = [-10, 10];
 var STEP = "auto";
 
 // Width of the graph in pixels
-// Let's use 400 for "normal" graphs and 170 for "small" graphs
-var SIZE = 400;
+// Let's use 320 for "normal" graphs and 170 for "small" graphs.
+// If this is for the background of a widget (transformer, interactive graph, etc), use 400.
+var SIZE = 320;
 
 var xScale;
 var yScale;
@@ -75,7 +76,9 @@ function setup() {
 var range = RANGE;
 
 /* The output's largest side is limited to this many pixels */
-var size = 400;
+// Let's use 320 for "normal" graphs and 170 for "small" graphs.
+// If this is for the background of a widget (transformer, interactive graph, etc), use 400.
+var SIZE = 320;
 
 setup();
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -105,7 +108,7 @@ var LABEL_THETA = true;
 var LABEL_DEGREES = false;  // ignored if LABEL_THETA is false
 
 // Width of the graph in pixels
-var SIZE = 400;
+var SIZE = 320;
 
 setup();
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -180,4 +183,199 @@ function setup() {
         "plot-points": 10000
     });
 }
+</script>
+
+<script id="sat-grid-setup-pre" type="text/graphie">
+// X and Y ranges of the graph
+var X_RANGE = [-10,10];
+var Y_RANGE = [-10, 10];
+
+// var STEP = [<x tick step>, <y tick step>];
+// var STEP = [10, 25];
+var STEP = "auto";
+
+// Largest dimension of the graph (excluding padding) in pixels
+// Let's use 320 for "normal" graphs and 170 for "small" graphs.
+// If this is for the background of a widget (transformer, interactive graph, etc), use 400.
+var SIZE = 320;
+
+// Make the graph twice as wide as tall. Only use for graphs for SAT prep. Axis arrows will only point in positive direction, and the there is an "O" label at the origin.
+var SATGraph=true; 
+
+// Keep the graph square, even if x and y have different ranges. This overrides the sizing of SATGraph, but not its other features.
+var squareGraph=false;
+
+var xScale;
+var yScale;
+setup();
+//////////////////////////////////////////////////////////////
+
+</script>
+
+<script id="sat-grid-setup-post" type="text/graphie">
+
+//////////////////////////////////////////////////////////////
+// Setup grid, ticks, and labels and initialize graph.
+function setup() {
+    var dimensions;
+    if(squareGraph){
+        dimensions = [SIZE, SIZE];
+    } else if(SATGraph){
+        dimensions = [SIZE, SIZE/2];
+    } else {
+        if((X_RANGE[1]-X_RANGE[0])>(Y_RANGE[1]-Y_RANGE[0])) {
+            dimensions = [SIZE, SIZE/(X_RANGE[1]-X_RANGE[0])*(Y_RANGE[1]-Y_RANGE[0])];
+        } else {
+            dimensions = [SIZE*(X_RANGE[1]-X_RANGE[0])/(Y_RANGE[1]-Y_RANGE[0]),SIZE];
+        }
+    }
+    var range = [X_RANGE, Y_RANGE];
+    var step = STEP;
+    if (step === "auto") {
+        step = _.map(range, function(extent, i) {
+            return Perseus.Util.tickStepFromExtent(
+                    extent, dimensions[i]);
+        });
+    }
+    if(SATGraph && !squareGraph){
+        step[1]*=2;
+    }
+    var gridConfig = _.map(range, function(extent, i) {
+        return Perseus.Util.gridDimensionConfig(
+                step[i],
+                extent,
+                dimensions[i]);
+    });
+    var scale = _.pluck(gridConfig, "scale");
+    xScale = scale[0];
+    yScale = scale[1];
+    var paddedRange = _.map(range, function(extent, i) {
+        var padding = 25 / scale[i];
+        return [extent[0], extent[1] + padding];
+    });
+    graphInit({
+        gridRange: range,
+        range: paddedRange,
+        scale: scale,
+        axes: SATGraph?false:true,
+        //Change this line for different axis labels
+        axisLabels: ["x","y"],
+        axisArrows: "<->",
+        labelFormat: function(s) {
+            return "\\small{" + s + "}";
+        },
+        gridStep: _.pluck(gridConfig, "gridStep"),
+        tickStep: _.pluck(gridConfig, "tickStep"),
+        labelStep: 1,
+        unityLabels: _.pluck(gridConfig, "unityLabel")
+    });
+    style({
+        clipRect: [[X_RANGE[0], Y_RANGE[0]],
+                [X_RANGE[1] - X_RANGE[0],
+                Y_RANGE[1] - Y_RANGE[0]]]
+    });
+    
+    label([0, Y_RANGE[1]], "y", "above");
+    label([X_RANGE[1], 0], "x", "right");
+    
+    if(SATGraph){
+        drawSATAxes();
+    }
+    function drawSATAxes(){
+        var axisCenter = [
+                Math.min(Math.max(X_RANGE[0], 0), X_RANGE[1]),
+                Math.min(Math.max(Y_RANGE[0], 0), Y_RANGE[1])
+            ];
+        path([[axisCenter[0],Y_RANGE[0]],[axisCenter[0],Y_RANGE[1]]],{arrows: true, stroke: BLACK, strokeOpacity: 1});
+        path([[X_RANGE[0],axisCenter[1]],[X_RANGE[1],axisCenter[1]]],{arrows: true, stroke: BLACK, strokeOpacity: 1});
+        if(axisCenter[0]===0 && axisCenter[1]===0) {
+            label([0,0],"O","below left");
+        }
+    }
+}
+
+</script>
+
+<script id="nonsquare-grid-setup-pre" type="text/graphie">
+// X and Y ranges of the graph
+var X_RANGE = [-10,10];
+var Y_RANGE = [-10, 10];
+
+// var STEP = [<x tick step>, <y tick step>];
+// var STEP = [10, 25];
+var STEP = "auto";
+
+// Largest dimension of the graph (excluding padding) in pixels
+// Let's use 320 for "normal" graphs and 170 for "small" graphs.
+// If this is for the background of a widget (transformer, interactive graph, etc), use 400.
+var SIZE = 320;
+
+// Keep the graph square, even if x and y have different ranges. Slope fields work best when this is false.
+var squareGraph=false;
+
+var xScale;
+var yScale;
+setup();
+//////////////////////////////////////////////////////////////
+
+</script>
+
+<script id="nonsquare-grid-setup-post" type="text/graphie">
+//////////////////////////////////////////////////////////////
+// Setup grid, ticks, and labels and initialize graph.
+function setup() {
+    var dimensions;
+    if(squareGraph){
+        dimensions = [SIZE, SIZE];
+    } else {
+        if((X_RANGE[1]-X_RANGE[0])>(Y_RANGE[1]-Y_RANGE[0])) {
+            dimensions = [SIZE, SIZE/(X_RANGE[1]-X_RANGE[0])*(Y_RANGE[1]-Y_RANGE[0])];
+        } else {
+            dimensions = [SIZE*(X_RANGE[1]-X_RANGE[0])/(Y_RANGE[1]-Y_RANGE[0]),SIZE];
+        }
+    }
+    var range = [X_RANGE, Y_RANGE];
+    var step = STEP;
+    if (step === "auto") {
+        step = _.map(range, function(extent, i) {
+            return Perseus.Util.tickStepFromExtent(
+                    extent, dimensions[i]);
+        });
+    }
+    var gridConfig = _.map(range, function(extent, i) {
+        return Perseus.Util.gridDimensionConfig(
+                step[i],
+                extent,
+                dimensions[i]);
+    });
+    var scale = _.pluck(gridConfig, "scale");
+    xScale = scale[0];
+    yScale = scale[1];
+    var paddedRange = _.map(range, function(extent, i) {
+        var padding = 25 / scale[i];
+        return [extent[0], extent[1] + padding];
+    });
+    graphInit({
+        gridRange: range,
+        range: paddedRange,
+        scale: scale,
+        axes: true,
+        //Change this line for different axis labels
+        axisLabels: ["x","y"],
+        axisArrows: "<->",
+        labelFormat: function(s) {
+            return "\\small{" + s + "}";
+        },
+        gridStep: _.pluck(gridConfig, "gridStep"),
+        tickStep: _.pluck(gridConfig, "tickStep"),
+        labelStep: 1,
+        unityLabels: _.pluck(gridConfig, "unityLabel")
+    });
+    style({
+        clipRect: [[X_RANGE[0], Y_RANGE[0]],
+                [X_RANGE[1] - X_RANGE[0],
+                Y_RANGE[1] - Y_RANGE[0]]]
+    });
+}
+
 </script>


### PR DESCRIPTION
- Resized any template larger than 320 pixels to 320 pixels or less. This was the compromise between creating images that would look reasonable on phone screens and still have a good level of detail on full screens.
- Changed bar graph template to actually be a bar graph instead of a histogram.
- Added automated label steps to templates 7, 27, 39, 43, and 47 to determine dynamically whether to label every tick or not
- Added two new templates - an SAT basic plot and a shade horizontal area between curves template
- Added two pairs of setup scripts - one for the SAT basic plot and nonsquare grid to improve the appearance of slope fields with different scales on the axes
- Flipped sequence of categories in the legends of templates 44 and 45 to match order entered at the top
- Assorted minor edits (addition of semicolons, updating colors to current palette, adding clarifying comments, trimming whitespace)
