### PR TITLE
FIX: Do not block backspace in ACE search field

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -173,10 +173,16 @@ keUtilsLoaded.then(function() {
             e.preventDefault();
             updateGraphie();
         } else if (e.keyCode === 8) { // Backspace
-            var message = "Are you sure you want to leave the page?";
-            var leave = window.confirm(message);
-            if (!leave) {
+            // Do nothing if focused in text box
+            // ACE search field doesn't have type attr so selecting by class
+            var textInputHasFocus =
+              $("input[type='text'], input.ace_search_field").is(':focus');
+            if (!textInputHasFocus) {
+              var message = "Are you sure you want to leave the page?";
+              var leave = window.confirm(message);
+              if (!leave) {
                 e.preventDefault();
+              }
             }
         }
     });
@@ -189,15 +195,6 @@ keUtilsLoaded.then(function() {
                 }
             })
             .on("click", updateGraphie);
-
-    $("input[type='text']").on("keydown", function(e) {
-        // To counter our code that prevents us from leaving the page when
-        // pressing backspace, we don't propogate events that start in text
-        // boxes.
-        if (e.keyCode === 8) {
-            e.stopPropagation();
-        }
-    });
 
     var throbber = $(".convert-throbber");
     throbber.hide();


### PR DESCRIPTION
We have a code that blocks the backspace keydown event with an alert window to prevent accidental go-to-previous-webpage, and another code that blocks that code in input text fields.

Unfortunately, this approach did not work for ACE search field because:
a) the search field element is added dynamically when Ctrl+F is first pressed
b) it does not have the "type" attribute.

I tested the new approach in the latest Firefox and Chromium on Linux.

Test plan:
 - `python app.py`
 - Try typing in 'Load rendered image' input field. Backspace should work as expected.
 - Open the ACE search field by Ctrl+F and test that backspace works. (this is what this PR fixes)
 - Focus out of the field, backspace should trigger a "Are you sure you want to leave this page" alert window.

Closes #8.