### PR TITLE
Keyboard shortcut for "Convert to Image" button

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -172,6 +172,10 @@ keUtilsLoaded.then(function() {
                 (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey) {
             e.preventDefault();
             updateGraphie();
+        } else if (e.keyCode === "I".charCodeAt(0) &&
+                (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey) {
+            e.preventDefault();
+            $(".btn-create-svg").click();
         } else if (e.keyCode === 8) { // Backspace
             // Do nothing if focused in text box
             // ACE search field doesn't have type attr so selecting by class
@@ -203,7 +207,15 @@ keUtilsLoaded.then(function() {
         $(this).select();
     });
 
-    $(".btn-create-svg").on("click", function(e) {
+    $(".btn-create-svg")
+       .val(function() {
+           if (isMac) {
+               return "Convert to Image (\u2318I)";
+           } else {
+               return "Convert to Image (Ctrl-I)";
+           }
+       })
+      .on("click", function(e) {
         throbber.show();
         var js = editor.getValue();
 


### PR DESCRIPTION
In certain exercises (long division), translators need to generate tens of Graphie images in `graphie-to-png` editor. We have a shortcut for Regraph, but then need to click the "Convert to Image" button anyway. Having an extra shortcut would speed up the process.

I am having trouble deciding which letter to use. Ideally, it would be close to 'R' (Ctrl+R is used for regraph), but E, D, F, G, T all do something (at least in Chrome). 

Test plan:
 - `python app.py`
 - Open http://localhost:5001/
 - `Convert to image` button text should include the new shortcut  
 - Type anything or load any Graphie and test that the shortcut works. (btw: in dev environment, you might get a rendering error when clicking a button but that's fine)
 - Please test on Mac, I don't own one so could not test.

Tracking JIRA ticket: [IC-539](https://khanacademy.atlassian.net/browse/IC-539)