### PR TITLE
Copy image link automatically to clipboard

### DIFF
--- a/static/css/graphie-to-png.css
+++ b/static/css/graphie-to-png.css
@@ -52,7 +52,7 @@ body {
     display: inline-block;
 }
 
-.link-copied {
+.link-copied, .link-explanation {
     display: none;
     padding: 2px;
     font-size: 12px;

--- a/static/css/graphie-to-png.css
+++ b/static/css/graphie-to-png.css
@@ -42,7 +42,7 @@ body {
     border-bottom: 1px solid #ccc;
 }
 #controls .image-link {
-    width: 300px;
+    width: 276px;
 }
 
 #preview {
@@ -50,4 +50,15 @@ body {
 }
 #preview > form {
     display: inline-block;
+}
+
+.link-copied {
+    display: none;
+    padding: 2px;
+    font-size: 12px;
+}
+
+.btn-rerender, .btn-create-svg {
+    width: 160px;
+    text-align: center;
 }

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -179,10 +179,6 @@ keUtilsLoaded.then(function() {
                 (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey) {
             e.preventDefault();
             $(".btn-create-svg").click();
-        } else if (e.keyCode === "C".charCodeAt(0) &&
-                (e.ctrlKey || e.metaKey) && !e.altKey && e.shiftKey) {
-            e.preventDefault();
-            copyImageLink();
         } else if (e.keyCode === 8) { // Backspace
             // Do nothing if focused in text box
             // ACE search field doesn't have type attr so selecting by class
@@ -222,6 +218,7 @@ keUtilsLoaded.then(function() {
                return "Convert to Image (Ctrl-I)";
            }
        })
+       //TODO(danielhollas):extract this to a function
       .on("click", function(e) {
         throbber.show();
         var js = editor.getValue();
@@ -240,6 +237,7 @@ keUtilsLoaded.then(function() {
             },
             success: function(data) {
                 $(".image-link").show().val(data);
+                copyImageLink();
             },
             error: function(a, b, error) {
                 $(".error-text").text("Error: " + error);

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -69,7 +69,10 @@
   <input type="button" value="Regraph" class="btn-rerender">
   <select class="example-selector"></select><br>
   <input type="button" value="Convert to Image" class="btn-create-svg">
-  <input type="text" class="image-link" readonly="" /><span class="error-text"></span><span class="convert-throbber"><img src="/static/images/throbber.gif" /></span>
+  <input type="text" class="image-link" readonly=""/>
+    <span class="error-text"></span>
+    <span class="convert-throbber"><img src="/static/images/throbber.gif" /></span>
+    <span class="link-copied">Copied!</span>
 </div>
 
 <div id="preview">
@@ -176,6 +179,10 @@ keUtilsLoaded.then(function() {
                 (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey) {
             e.preventDefault();
             $(".btn-create-svg").click();
+        } else if (e.keyCode === "C".charCodeAt(0) &&
+                (e.ctrlKey || e.metaKey) && !e.altKey && e.shiftKey) {
+            e.preventDefault();
+            copyImageLink();
         } else if (e.keyCode === 8) { // Backspace
             // Do nothing if focused in text box
             // ACE search field doesn't have type attr so selecting by class
@@ -289,6 +296,15 @@ keUtilsLoaded.then(function() {
             loadUrl(url);
         }
     });
+
+    function copyImageLink() {
+        var link = $(".image-link:visible");
+        if (link.length > 0) {
+          link.select();
+          document.execCommand("copy");
+          $(".link-copied").show().delay(1000).fadeOut();
+        }
+    };
 
     var storedValue = null;
     var formSubmit = $(".btn-create-svg");

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -68,10 +68,11 @@
 <div id="controls">
   <input type="button" value="Regraph" class="btn-rerender">
   <select class="example-selector"></select><br>
-  <input type="button" value="Convert to Image" class="btn-create-svg">
+  <input type="button" value="Convert to Image" title="Link will be copied to clipboard automatically" class="btn-create-svg">
   <input type="text" class="image-link" readonly=""/>
     <span class="error-text"></span>
     <span class="convert-throbber"><img src="/static/images/throbber.gif" /></span>
+    <span class="link-explanation">Link will be copied to clipboard automatically.</span>
     <span class="link-copied">Copied!</span>
 </div>
 
@@ -204,7 +205,9 @@ keUtilsLoaded.then(function() {
             .on("click", updateGraphie);
 
     var throbber = $(".convert-throbber");
+    var linkExplain = $(".link-explanation");
     throbber.hide();
+    linkExplain.hide();
 
     $(".image-link").hide().click(function() {
         $(this).select();
@@ -218,36 +221,7 @@ keUtilsLoaded.then(function() {
                return "Convert to Image (Ctrl-I)";
            }
        })
-       //TODO(danielhollas):extract this to a function
-      .on("click", function(e) {
-        throbber.show();
-        var js = editor.getValue();
-
-        // To get identical hashes to the old graphie-to-png, we replace all
-        // newlines with "\r\n"
-        js = js.replace(/\r\n|\n|\r/g, "\r\n");
-
-        $(".error-text").text("");
-        $(".image-link").hide().val("");
-        $.ajax({
-            url: "/svg",
-            type: "POST",
-            data: {
-                js: js
-            },
-            success: function(data) {
-                $(".image-link").show().val(data);
-                copyImageLink();
-            },
-            error: function(a, b, error) {
-                $(".error-text").text("Error: " + error);
-            },
-            complete: function() {
-                throbber.hide();
-            }
-        });
-    });
-
+      .on("click", createSvg);
 
     var urlStart =
         "(?:" +
@@ -302,7 +276,38 @@ keUtilsLoaded.then(function() {
           document.execCommand("copy");
           $(".link-copied").show().delay(1000).fadeOut();
         }
-    };
+    }
+
+    function createSvg() {
+        throbber.show();
+        linkExplain.show();
+        var js = editor.getValue();
+
+        // To get identical hashes to the old graphie-to-png, we replace all
+        // newlines with "\r\n"
+        js = js.replace(/\r\n|\n|\r/g, "\r\n");
+
+        $(".error-text").text("");
+        $(".image-link").hide().val("");
+        $.ajax({
+            url: "/svg",
+            type: "POST",
+            data: {
+                js: js
+            },
+            success: function(data) {
+                $(".image-link").show().val(data);
+                copyImageLink();
+            },
+            error: function(a, b, error) {
+                $(".error-text").text("Error: " + error);
+            },
+            complete: function() {
+                throbber.hide();
+                linkExplain.hide();
+            }
+        });
+    }
 
     var storedValue = null;
     var formSubmit = $(".btn-create-svg");


### PR DESCRIPTION
#10 introduced a keyboard shortcut for creating a Graphie link but users still need to select and copy the link manually. Let's just copy the link to clipboard automatically for them!

(I also clumsily tried to tweak the CSS.)
Before:
![image](https://user-images.githubusercontent.com/9539441/73598262-4a943980-4536-11ea-9354-03f875d000f5.png)

After:
![image](https://user-images.githubusercontent.com/9539441/73598277-816a4f80-4536-11ea-8a05-390dcb107ae7.png)

The "Copied!" text is displayed for 1s and fades out.

JIRA: https://khanacademy.atlassian.net/browse/IC-601

(requested by one of the translators and discussed with Caroline on JIRA)