### PR TITLE
Copy button instead of autocopy

### DIFF
--- a/static/css/graphie-to-png.css
+++ b/static/css/graphie-to-png.css
@@ -42,7 +42,12 @@ body {
     border-bottom: 1px solid #ccc;
 }
 #controls .image-link {
-    width: 276px;
+    width: 50%;
+    font-size: 12px
+}
+
+#controls .example-selector {
+  font-size: 12px;
 }
 
 #preview {
@@ -52,13 +57,30 @@ body {
     display: inline-block;
 }
 
-.link-copied, .link-explanation {
+.link-copied {
     display: none;
     padding: 2px;
     font-size: 12px;
 }
 
+.i-copy-link {
+  background: url("../images/copy-link.svg") center center no-repeat;
+  background-size: contain;
+  border: none;
+}
+
+.i-copy-link:hover {
+  background-color: #e6e6e6;
+}
+
+.i-copy-link:active {
+  background-color: #ffffff;
+}
+
 .btn-rerender, .btn-create-svg {
-    width: 160px;
+    width: 35%;
+    padding-left: 2px;
+    padding-right: 2px;
+    font-size: 12px;
     text-align: center;
 }

--- a/static/images/copy-link.svg
+++ b/static/images/copy-link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="70.643" height="77.724" viewBox="0 0 70.643441 77.723611"><g fill="none" stroke="#000" stroke-width="2"><path d="M15.136 14.135h54.466v62.548H15.136z"/><path d="M3.113 59.536V3.046h52.449"/></g></svg>

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -67,13 +67,14 @@
 
 <div id="controls">
   <input type="button" value="Regraph" class="btn-rerender">
-  <select class="example-selector"></select><br>
-  <input type="button" value="Convert to Image" title="Link will be copied to clipboard automatically" class="btn-create-svg">
+  <select class="example-selector"></select>
+  <span class="link-copied">Copied!</span>
+  <br>
+  <input type="button" value="Convert to Image" class="btn-create-svg">
   <input type="text" class="image-link" readonly=""/>
-    <span class="error-text"></span>
-    <span class="convert-throbber"><img src="/static/images/throbber.gif" /></span>
-    <span class="link-explanation">Link will be copied to clipboard automatically.</span>
-    <span class="link-copied">Copied!</span>
+  <input type="button" value=" " title="Copy link to clipboard" class="btn-copy-link i-copy-link">
+  <span class="error-text"></span>
+  <span class="convert-throbber"><img src="/static/images/throbber.gif" /></span>
 </div>
 
 <div id="preview">
@@ -205,9 +206,11 @@ keUtilsLoaded.then(function() {
             .on("click", updateGraphie);
 
     var throbber = $(".convert-throbber");
-    var linkExplain = $(".link-explanation");
+    var linkCopied = $(".link-copied");
     throbber.hide();
-    linkExplain.hide();
+    linkCopied.hide();
+
+    $(".btn-copy-link").hide().on("click", copyImageLink);
 
     $(".image-link").hide().click(function() {
         $(this).select();
@@ -273,14 +276,14 @@ keUtilsLoaded.then(function() {
         var link = $(".image-link:visible");
         if (link.length > 0) {
           link.select();
-          document.execCommand("copy");
-          $(".link-copied").show().delay(1000).fadeOut();
+          if (document.execCommand("copy")) {
+            linkCopied.show().delay(1000).fadeOut();
+          }
         }
     }
 
     function createSvg() {
         throbber.show();
-        linkExplain.show();
         var js = editor.getValue();
 
         // To get identical hashes to the old graphie-to-png, we replace all
@@ -289,6 +292,7 @@ keUtilsLoaded.then(function() {
 
         $(".error-text").text("");
         $(".image-link").hide().val("");
+        $(".btn-copy-link").hide();
         $.ajax({
             url: "/svg",
             type: "POST",
@@ -296,15 +300,14 @@ keUtilsLoaded.then(function() {
                 js: js
             },
             success: function(data) {
-                $(".image-link").show().val(data);
-                copyImageLink();
+                $(".image-link").show().val(data).select();
+                $(".btn-copy-link").show();
             },
             error: function(a, b, error) {
                 $(".error-text").text("Error: " + error);
             },
             complete: function() {
                 throbber.hide();
-                linkExplain.hide();
             }
         });
     }
@@ -350,6 +353,7 @@ keUtilsLoaded.then(function() {
 
             $(".error-text").text("");
             $(".image-link").hide().val("");
+            $(".btn-copy-link").hide();
         } catch (e) {
             $("#output > div")
                     .addClass("error")


### PR DESCRIPTION
**Summary**:
The auto-copy feature from previous commit only worked in Chrome, see:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard

Instead, we now:
1. Auto-select the graphie link so users can use
standard copy keyboard shortcut rightaway without clicking
2. display copy-link button next to the link

I also fixed couple of smaller issues with previous commit.
 1) Improve layout in Firefox
 2) Hide "Copied" in Chromium on Mac on page load.
 3) Check whether the link was actually copied into clipboard
    before displaying the "Copied" message.

**Test plan:**
 - Test the new features in Firefox, Chrome and Safari
 - Verify the layout is the same in different browsers

**Screenshots**

Firefox before:
![image](https://user-images.githubusercontent.com/9539441/74781443-c7971100-52a1-11ea-899b-9bb3fbbd313d.png)

Firefox after:
![image](https://user-images.githubusercontent.com/9539441/74781394-b5b56e00-52a1-11ea-89b9-b7a1f579d617.png)