### PR TITLE
Pin the versions of setuptools and itsdangerous

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ svg.path==2.1.1
 MarkupSafe<1.0.0
 # This forces flask to use a python2 (?) version of this lib
 click==7.1.2
+# This forces svg.path to use a python2 version of this lib
+setuptools==44.1.1
+# This forces flask to use a python2 version of this lib
+itsdangerous==1.1.0


### PR DESCRIPTION
## Summary:
The `svg.path` library on which this app depends does not pin the
versions of its own dependencies, including `setuptools`. As a result,
`pip` was trying to install a version of `setuptools` that is not
compatible with python 2.

There was a similar issue with `itsdangerous`.

Issue: https://khanacademy.atlassian.net/browse/LC-1002

## Test plan:

```
pip install -r requirements.txt -t /tmp
```
should run without errors.