### PR TITLE
Add a warning label to the Graphie preview

### DIFF
--- a/static/css/graphie-to-png.css
+++ b/static/css/graphie-to-png.css
@@ -36,6 +36,14 @@ body {
     display: block;
     margin-top: 3px;
 }
+#caveats {
+    margin: 0.2em 0 1em;
+    color: rgba(33,36,44,0.64);
+}
+#caveats:before {
+    display: inline;
+    content: 'ⓘ ';
+}
 
 #controls {
     padding: 5px;

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -86,6 +86,7 @@
 </div>
 
 <div id="output">
+  <p id="caveats">This preview is approximate. Please review graphies in the exercise editor before publishing.</p>
   <div class="graphie"></div>
   <span class="size"></span>
 </div>


### PR DESCRIPTION
## Summary:
graphie-to-png uses KaTeX to render math-formatted labels, while webapp
uses MathJax. The most noticeable difference between these is that
labels rendered by KaTeX can wrap across multiple lines, while labels
rendered by MathJax can't.

This commit adds a warning label so content creators know to look at the
exercise editor preview, which is more accurate.

Issue: https://khanacademy.atlassian.net/browse/LC-1312

Test plan:

- Deploy this change by following the instructions at https://github.com/Khan/internal-services/tree/master/graphie-to-png
- Confirm that the warning text appears above the preview, as in the
  following screenshot.

<img width="1190" alt="Screen Shot 2023-10-24 at 2 05 22 PM" src="https://github.com/Khan/graphie-to-png/assets/693920/ce043c59-883d-49ca-b9ac-e4bf0813394a">