### PR TITLE
Skip S3 upload if the file already exists

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,11 +58,12 @@ def _put_to_s3(key, data, mimetype):
 
     k = boto.s3.key.Key(bucket)
     k.key = key
-    k.set_contents_from_string(
-            data,
-            headers={'Content-Type': mimetype},
-            policy='public-read',
-        )
+    if not k.exists():
+        k.set_contents_from_string(
+                data,
+                headers={'Content-Type': mimetype},
+                policy='public-read',
+            )
 
     return k.generate_url(expires_in=0, query_auth=False)
 

--- a/app.py
+++ b/app.py
@@ -35,11 +35,12 @@ def svg():
     other_data = request.form['other_data']
 
     hash = hashlib.sha1(js.encode('utf-8')).hexdigest()
-    _put_to_s3('%s.js' % hash, js, 'application/javascript')
-    _put_to_s3('%s-data.json' % hash,
-               _jsonp_wrap(other_data, 'svgData%s' % hash), 'application/json')
-    svg_url = _put_to_s3('%s.svg' % hash, cleanup_svg.cleanup_svg(svg),
-                         'image/svg+xml')
+    _maybe_upload_to_s3('%s.js' % hash, js, 'application/javascript')
+    _maybe_upload_to_s3('%s-data.json' % hash,
+                        _jsonp_wrap(other_data, 'svgData%s' % hash),
+                        'application/json')
+    svg_url = _maybe_upload_to_s3('%s.svg' % hash, cleanup_svg.cleanup_svg(svg),
+                                  'image/svg+xml')
 
     return (svg_url.
             replace("https://", "web+graphie://").
@@ -51,7 +52,7 @@ def _jsonp_wrap(data, func_name):
     return '%s(%s);' % (func_name, data)
 
 
-def _put_to_s3(key, data, mimetype):
+def _maybe_upload_to_s3(key, data, mimetype):
     conn = boto.s3.connection.S3Connection(
             boto_secrets.aws_access_key_id,
             boto_secrets.aws_secret_access_key,

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import hashlib
+import logging
 import os
 
 import boto
@@ -14,6 +15,7 @@ import cleanup_svg
 import boto_secrets
 
 app = flask.Flask(__name__)
+app.logger.setLevel(logging.INFO)
 root = os.path.realpath(os.path.dirname(__file__))
 
 
@@ -58,7 +60,9 @@ def _put_to_s3(key, data, mimetype):
 
     k = boto.s3.key.Key(bucket)
     k.key = key
-    if not k.exists():
+    if k.exists():
+        app.logger.info('File already exists, skipping upload: %s' % key)
+    else:
         k.set_contents_from_string(
                 data,
                 headers={'Content-Type': mimetype},


### PR DESCRIPTION
## Summary:
Graphie content should be immutable and is intended to be derived from the
input JavaScript, so we can skip uploading if files already exist.

Issue: CP-8797

## Test plan:
Locally I created a new Graphie with the "Convert to Image" button. I clicked
the button again and ensured with logging that the files were not reuploaded.