### PR TITLE
Fix graphie-to-png request entity too large error

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def svg():
     # parse the largest of Graphies in our template bank submitted in the body.
     # But we also need to ensure that the request itself is not too large so as
     # to represent a security issue.
-    if request.content_length > 1500000:
+    if request.content_length > 3000000:
         return "Request entity too large", 413
     # https://flask.palletsprojects.com/en/stable/web-security/#resource-use
     # https://flask.palletsprojects.com/en/stable/config/#MAX_FORM_MEMORY_SIZE

--- a/app.py
+++ b/app.py
@@ -30,6 +30,16 @@ def svg():
 
     Returns a web+graphie link as the response.
     """
+    # We're having to disable max_form_memory_size in order to be able to
+    # parse the largest of Graphies in our template bank submitted in the body.
+    # But we also need to ensure that the request itself is not too large so as
+    # to represent a security issue.
+    if request.content_length > 1500000:
+        return "Request entity too large", 413
+    # https://flask.palletsprojects.com/en/stable/web-security/#resource-use
+    # https://flask.palletsprojects.com/en/stable/config/#MAX_FORM_MEMORY_SIZE
+    request.max_form_memory_size = None
+
     js = request.form['js']
     svg = request.form['svg']
     other_data = request.form['other_data']


### PR DESCRIPTION
## Summary:
This error happens when accessing `request.form` for certain POST bodies
submitted by the frontend.

I have no idea why this error happens, but it appears to orginate inside the
`werkzeug` which `flask` uses.

The workaround is to disable `max_form_memory_size` on the request.

What's more confusing is that the Flask documentation refers to `multipart/form-data`,
but the frontend submits `application/x-www-form-urlencoded` Content-Type.

Issue: https://khanacademy.atlassian.net/browse/CP-8837

Test Plan:
 - In https://github.com/Khan/internal-services/tree/master/graphie-to-png `make build` (don't forget to change to `docker buildx build --platform=linux/amd64 -t ...`)
 - Verify http://graphie-to-png.khanacademy.systems/ opens
 - Load `web+graphie://ka-perseus-graphie.s3.amazonaws.com/94c6fd71969d592035de04c24e57911a66dc8f51`
 - Click "Convert to Image" button and verify no `Error: REQUEST ENTITY TOO LARGE` is returned