### PR TITLE
Add checks for unsafe methods and notify users if found

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,12 +26,9 @@ def editor():
 
 def contains_forbidden_js(js_code):
     """
-    Parses JavaScript code and checks for:
-    - Function calls to eval(), alert(), require(), Function()
-    - References to document in expressions
+    Parses JavaScript code and checks for function calls to eval(), alert()
     """
-    forbidden_calls = {"eval", "alert", "require", "Function"}
-    forbidden_identifiers = {"document"}
+    forbidden_calls = {"eval", "alert"}
 
     try:
         # Parse JavaScript into AST and convert to dictionary
@@ -45,23 +42,17 @@ def contains_forbidden_js(js_code):
             if not isinstance(node, dict) or 'type' not in node:
                 continue
 
-            # Check for function calls like eval(), alert(), require(), Function()
+            # Check for function calls eval() and alert()
             if node["type"] == "CallExpression" and "callee" in node:
                 callee = node["callee"]
                 if callee.get("type") == "Identifier" and callee.get("name") in forbidden_calls:
                     return f"Error: Forbidden function '{callee['name']}' used", 400
 
-            # Check for usage of 'document' (e.g., document.getElementById())
-            if node["type"] == "MemberExpression" and "object" in node:
-                obj = node["object"]
-                if obj.get("type") == "Identifier" and obj.get("name") in forbidden_identifiers:
-                    return f"Error: Forbidden identifier '{obj['name']}' used", 400
-
             # Add child nodes to the stack for further inspection
             for key, value in node.items():
-                if isinstance(value, dict):  # If it's a nested object, add it to the stack
+                if isinstance(value, dict):
                     stack.append(value)
-                elif isinstance(value, list):  # If it's a list of nodes, add all to the stack
+                elif isinstance(value, list):
                     stack.extend([child for child in value if isinstance(child, dict)])
 
         return None

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import boto.s3.connection
 import boto.s3.key
 import flask
 from flask import request
+import esprima
 
 import cleanup_svg
 
@@ -23,6 +24,50 @@ root = os.path.realpath(os.path.dirname(__file__))
 def editor():
     return flask.render_template('editor.html')
 
+def contains_forbidden_js(js_code):
+    """
+    Parses JavaScript code and checks for:
+    - Function calls to eval(), alert(), require(), Function()
+    - References to document in expressions
+    """
+    forbidden_calls = {"eval", "alert", "require", "Function"}
+    forbidden_identifiers = {"document"}
+
+    try:
+        # Parse JavaScript into AST and convert to dictionary
+        tree = esprima.parseScript(js_code, tolerant=True).toDict()
+        
+        stack = [tree]
+
+        while stack:
+            node = stack.pop()
+
+            if not isinstance(node, dict) or 'type' not in node:
+                continue
+
+            # Check for function calls like eval(), alert(), require(), Function()
+            if node["type"] == "CallExpression" and "callee" in node:
+                callee = node["callee"]
+                if callee.get("type") == "Identifier" and callee.get("name") in forbidden_calls:
+                    return f"Error: Forbidden function '{callee['name']}' used", 400
+
+            # Check for usage of 'document' (e.g., document.getElementById())
+            if node["type"] == "MemberExpression" and "object" in node:
+                obj = node["object"]
+                if obj.get("type") == "Identifier" and obj.get("name") in forbidden_identifiers:
+                    return f"Error: Forbidden identifier '{obj['name']}' used", 400
+
+            # Add child nodes to the stack for further inspection
+            for key, value in node.items():
+                if isinstance(value, dict):  # If it's a nested object, add it to the stack
+                    stack.append(value)
+                elif isinstance(value, list):  # If it's a list of nodes, add all to the stack
+                    stack.extend([child for child in value if isinstance(child, dict)])
+
+        return None
+
+    except Exception as e:
+        return f"Error parsing JavaScript: {str(e)}", 400
 
 @app.route('/svg', methods=['POST'])
 def svg():
@@ -44,6 +89,11 @@ def svg():
     svg = request.form['svg']
     other_data = request.form['other_data']
 
+    # Check JavaScript security using AST
+    js_error = contains_forbidden_js(js)
+    if js_error:
+        return js_error
+
     hash = hashlib.sha1(js.encode('utf-8')).hexdigest()
     _maybe_upload_to_s3('%s.js' % hash, js, 'application/javascript')
     _maybe_upload_to_s3('%s-data.json' % hash,
@@ -56,7 +106,6 @@ def svg():
             replace("https://", "web+graphie://").
             replace(".svg", "").
             replace(":443", ""))
-
 
 def _jsonp_wrap(data, func_name):
     return '%s(%s);' % (func_name, data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+esprima==4.0.1
 Flask==3.0.3
 Jinja2==3.1.4
 boto==2.49.0

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -306,7 +306,8 @@ keUtilsLoaded.then(function() {
                 $(".btn-copy-link").show();
             },
             error: function(a, b, error) {
-                $(".error-text").text("Error: " + error);
+                var errorMessage = a.responseText || "Error: " + error;
+                $(".error-text").text(errorMessage);
             },
             complete: function() {
                 throbber.hide();


### PR DESCRIPTION
## Summary:
A number of graphies were recently quarantined because their `js` files were found to contain unsafe methods. To help our content creators, this PR adds a check for those methods and notifies via an error message when converting to image if found.

Issue: [CP-9098](https://khanacademy.atlassian.net/browse/CP-9098)

## Test plan:
-comment out all the references to `boto` in `app.py`
-add return string to verify happy path 

```
cd khan/graphie-to-png/
git fetch
git pull
virtualenv -p python3 graphie-to-png
source graphie-to-png/bin/activate
make deps
git submodule update --init --recursive
./server.sh
```
**NOTE**: `git submodule update --init --recursive` was necessary for me because the ace-builds editor didn't load properly when first running the server.

-test against a variety of cases
```
// UNSAFE

// eval("console.log('test')");

// alert("Hello!");

// var heading = document.getElementById("title");

// function require() {
//     console.log("This function should not exist!");
// }
// require("custom-module");


// SAFE: Using the words in a string should NOT be blocked
// console.log("This is just a message about require.");

// console.log("The word eval should not be blocked in strings.");
```

https://github.com/user-attachments/assets/19880cea-dc87-47fb-a622-cc88358559da

[CP-9098]: https://khanacademy.atlassian.net/browse/CP-9098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ